### PR TITLE
Update Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,22 @@
 language: c
-env:
-  global:
-    - GAPROOT=gaproot
-    - COVDIR=coverage
 
 addons:
-  apt_packages:
+  apt:
+    packages:
     - libgmp-dev
     - libreadline-dev
-    - libgmp-dev:i386
-    - libreadline-dev:i386
-    - gcc-multilib
-    - g++-multilib
+    - zlib1g-dev
 
 matrix:
   include:
-    - env: CFLAGS="-O2" CC=clang CXX=clang++
-      compiler: clang
-    - env: CFLAGS="-O2"
-      compiler: gcc
-    - env: ABI=32
+    - env: GAPBRANCH=master
+    - env: GAPBRANCH=stable-4.10
 
 branches:
   only:
     - master
 
 before_script:
-  - export GAPROOT="$HOME/gap"
   - git clone https://github.com/gap-system/pkg-ci-scripts.git scripts
   - scripts/build_gap.sh
 script:


### PR DESCRIPTION
This package contains no compiled code, so there is little point in testing it
with alternate compilers or 32bit GAP.

Instead, let's test against both master and stable-4.10, to make sure that the
package works both in GAP 4.10.x and 4.11.x.