### PR TITLE
added `CentralProduct`

### DIFF
--- a/doc/groups.xml
+++ b/doc/groups.xml
@@ -243,6 +243,68 @@ true
 
 
 <ManSection>
+<Oper Name="CentralProduct" Arg="G1, G2, Z1, Phi" />
+<Attr Name="CentralProductInfo" Arg="G"/>
+
+<Description>
+Let <A>G1</A> and <A>G2</A> be two groups,
+<A>Z1</A> be a central subgroup of <A>G1</A>,
+and <A>Phi</A> be an isomorphism from <A>Z1</A> to a central subgroup of
+<A>G2</A>.
+The <E>central product</E> defined by these arguments is the factor group of
+the direct product of <A>G1</A> and <A>G2</A> by the central subgroup
+<M>\{ (z, <A>Phi</A>(z)^{-1}); z \in <A>Z1</A> \}</M>.
+<P/>
+The attribute <Ref Attr="CentralProductInfo"/> of a group <M>G</M>
+that has been created by <Ref Oper="CentralProduct"/>
+is similar to <Ref Attr="PullbackInfo"/> for pullback groups.
+Its value is a record with the following components.
+<P/>
+<List>
+<Mark><C>projection</C></Mark>
+<Item>
+  the epimorphism from the direct product of <A>G1</A> and <A>G2</A>
+  to <M>G</M>, and
+</Item>
+<Mark><C>phi</C></Mark>
+<Item>
+  the map <A>Phi</A>.
+</Item>
+</List>
+
+Note that one can access the direct product as the
+<Ref Attr="Source" BookName="ref"/> value of the <C>projection</C> map,
+and one can access <A>G1</A> and <A>G2</A> as the two embeddings of this
+direct product, see <Ref Oper="Embedding" BookName="ref"/>.
+
+<Example><![CDATA[
+gap> g:= DihedralGroup( 8 );
+<pc group of size 8 with 3 generators>
+gap> c:= Centre( g );
+Group([ f3 ])
+gap> cp:= CentralProduct( g, g, c, IdentityMapping( c ) );
+Group([ f1, f2, f5, f3, f4, f5 ])
+gap> IdGroup( cp ) = IdGroup( ExtraspecialGroup( 2^5, "+" ) );
+true
+gap> g:= QuaternionGroup( 8 );
+<pc group of size 8 with 3 generators>
+gap> c:= Centre( g );
+Group([ y2 ])
+gap> cp:= CentralProduct( g, g, c, IdentityMapping( c ) );
+Group([ f1, f2, f5, f3, f4, f5 ])
+gap> IdGroup( cp ) = IdGroup( ExtraspecialGroup( 2^5, "+" ) );
+true
+gap> info:= CentralProductInfo( cp );
+rec( phi := IdentityMapping( Group([ y2 ]) ), 
+  projection := [ f1, f2, f3, f4, f5, f6 ] -> [ f1, f2, f5, f3, f4, f5 ] )
+gap> Source( Embedding( Source( info.projection ), 1 ) ) = g;
+true
+]]></Example>
+</Description>
+</ManSection>
+
+
+<ManSection>
    <Oper Name="IdempotentEndomorphisms"
          Arg="G" />
    <Attr Name="IdempotentEndomorphismsData"

--- a/lib/maps.gd
+++ b/lib/maps.gd
@@ -23,6 +23,15 @@ DeclareOperation( "Pullback", [ IsGroupHomomorphism, IsGroupHomomorphism ] );
 DeclareAttribute( "PullbackInfo", IsGroup, "mutable" );
 
 #############################################################################
+##
+#O  CentralProduct( <G1>, <G2>, <Z1>, <Phi> )
+#A  CentralProductInfo( <cp> )
+##
+DeclareOperation( "CentralProduct",
+    [ IsGroup, IsGroup, IsGroup, IsGroupHomomorphism ] );
+DeclareAttribute( "CentralProductInfo", IsGroup, "mutable" );
+
+#############################################################################
 ##  these functions compute idempotent endomorphisms on G with image R 
 ## 
 #O  IdempotentEndomorphisms( <G> ) 

--- a/lib/maps.gi
+++ b/lib/maps.gi
@@ -66,6 +66,37 @@ function( nu, mu )
     return L;
 end ); 
 
+#############################################################################
+##
+#M  CentralProduct( <G1>, <G2>, <Z1>, <Phi> )
+##
+InstallMethod( CentralProduct,
+    [ "IsGroup", "IsGroup", "IsGroup", "IsGroupHomomorphism" ],
+    function( G1, G2, Z1, Phi )
+    local gens, imgs, dp, emb1, emb2, N, proj, G;
+
+    if not ( IsSubset( G1, Z1 ) and IsCentral( G1, Z1 ) ) then
+      Error( "<Z1> must be a central subgroup of <G1>" );
+    fi;
+    gens:= GeneratorsOfGroup( Z1 );
+    imgs:= List( gens, x -> (x^-1)^Phi );
+    if not ( IsSubset( G2, imgs ) and
+             ForAll( imgs, x -> IsCentral( G2, x ) ) ) then
+      Error( "<Phi> must map <Z1> to a central subgroup of <G2>" );
+    fi;
+
+    dp:= DirectProduct( G1, G2 );
+    emb1:= Embedding( dp, 1 );
+    emb2:= Embedding( dp, 2 );
+    N:= SubgroupNC( dp,
+            List( [ 1 .. Length( gens ) ], i -> gens[i]^emb1 * imgs[i]^emb2 ) );
+    proj:= NaturalHomomorphismByNormalSubgroup( dp, N );
+    G:= Image( proj );
+    SetCentralProductInfo( G, rec( projection:= proj, phi:= Phi ) );
+
+    return G;
+end );
+
 ##############################################################################
 ##
 #M  IdempotentEndomorphisms  . . . . . . . . . . . . . . . . . . . for a group  

--- a/tst/groups.tst
+++ b/tst/groups.tst
@@ -108,6 +108,40 @@ gap> a*b in Pfi;
 true
 
 ## SubSection 5.2.3
+gap> g:= DihedralGroup( 8 );
+<pc group of size 8 with 3 generators>
+gap> c:= Centre( g );
+Group([ f3 ])
+gap> cp:= CentralProduct( g, g, c, IdentityMapping( c ) );
+Group([ f1, f2, f5, f3, f4, f5 ])
+gap> IdGroup( cp ) = IdGroup( ExtraspecialGroup( 2^5, "+" ) );
+true
+gap> g:= QuaternionGroup( 8 );
+<pc group of size 8 with 3 generators>
+gap> c:= Centre( g );
+Group([ y2 ])
+gap> cp:= CentralProduct( g, g, c, IdentityMapping( c ) );
+Group([ f1, f2, f5, f3, f4, f5 ])
+gap> IdGroup( cp ) = IdGroup( ExtraspecialGroup( 2^5, "+" ) );
+true
+gap> info:= CentralProductInfo( cp );
+rec( phi := IdentityMapping( Group([ y2 ]) ), 
+  projection := [ f1, f2, f3, f4, f5, f6 ] -> [ f1, f2, f5, f3, f4, f5 ] )
+gap> Source( Embedding( Source( info.projection ), 1 ) ) = g;
+true
+gap> g:= SymmetricGroup( 3 );
+Sym( [ 1 .. 3 ] )
+gap> c:= TrivialSubgroup( g );
+Group(())
+gap> cp:= CentralProduct( g, g, c, IdentityMapping( c ) );
+Group([ (1,2,3), (1,2), (4,5,6), (4,5) ])
+gap> info:= CentralProductInfo( cp );
+rec( phi := IdentityMapping( Group(()) ), 
+  projection := IdentityMapping( Group([ (1,2,3), (1,2), (4,5,6), (4,5) ]) ) )
+gap> Source( Embedding( Source( info.projection ), 1 ) ) = g;
+true
+
+## SubSection 5.2.4
 gap> gens := [ (1,2,3,4), (1,2)(3,4) ];; 
 gap> d8 := Group( gens );;
 gap> SetName( d8, "d8" );
@@ -155,7 +189,7 @@ gap> idemim2 :=
 gap> ForAll( idemim, m -> ( m in idemim2 ) ); 
 true
 
-## SubSection 5.2.4
+## SubSection 5.2.5
 gap> c4 := Group( (1,2,3,4) );; 
 gap> c2 := Group( (5,6) );; 
 gap> f1 := GroupHomomorphismByImages( c4, c2, [(1,2,3,4)], [(5,6)] );;
@@ -171,7 +205,7 @@ gap> f := DirectProductOfFunctions( c4c3, c2c6, f1, f2 );
 gap> ImageElm( f, (1,4,3,2)(5,7,6) ); 
 (1,2)(3,7,5)(4,8,6)
 
-## SubSection 5.2.5
+## SubSection 5.2.6
 gap> c9 := Group( (1,2,3,4,5,6,7,8,9) );; 
 gap> ac9 := AutomorphismGroup( c9 );; 
 gap> q8 := QuaternionGroup( IsPermGroup, 8 );;


### PR DESCRIPTION
It turned out in a discussion with Hongyi Zhao that `CentralProduct` is of interest but not available in GAP.
The utils package seems to be a suitable place for it, for example because the related function `Pullback` does belong to this package.