### PR TITLE
added tests for left cosets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,110 +1,93 @@
 # CHANGES log for the 'Utils' package
 
-## Version 0.74 for GAP 4.11.1 (09/07/22) 
+## Version 0.75 for GAP 4.11.1 (22/07/22) 
+ * (15/07/22) added LeftCoset operations 
 
+## Version 0.74 for GAP 4.11.1 (09/07/22) 
  * (07/07/22) Max Horn replaced BIND_GLOBAL with BindGlobal (transfer process) 
  * (05/07/22) CentralProduct added by Thomas Breuer 
 
 ## Version 0.72 for GAP 4.10.1 (16/11/21) 
-
  * (06/04/21) Switch CI to use GitHub Actions: PR#37
 
 ## Version 0.69 for GAP 4.10.2 (29/11/19) 
-
  * (22/11/19) added DirectProductOfAutomorphismGroups 
  * (19/11/19) added DirectProductOfFunctions 
 
 ## Version 0.67 for GAP 4.10.2 (04/09/19) 
-
  * (04/09/19) accepted PR34 - changed example in 6.2.1 
  * (25/08/19) fixed typos with UnorderedPairsIterator in manual 
 
 ## Version 0.65 for GAP 4.10.2 (11/07/19) 
-
  * (11/07/19) groups.tst fails in gapdev - temporary(?) fix 
 
 ## Version 0.64 for GAP 4.10.1 (17/06/19) 
-
  * (14/06/19) added Iterators chapter: AllSubgroupsIterator
               CartesianIterator, UnorderedPairsIterator
 
 ## Version 0.63 for GAP 4.10.1 (29/05/19) 
-
  * (28/05/19) added IdempotentEndomorphisms, IdempotentEndomorphismsData
  * (17/05/19) + AllIsomorphismsIterator, AllIsomorphismsNumber, AllIsomorphisms
  * (16/02/19) added License field in PackageInfo.g 
 
 ## Version 0.61 for GAP 4.10.0 (28/11/18) 
-
  * (28/11/18) made ExponentOfPrime obsolete
  * (27/11/18) made several AutoDoc functions obsolete (they remain in AutoDoc): 
            FindMatchingFiles; CreateDirIfMissing; StringDotSuffix; SetIfMissing
 
 ## Version 0.59 for GAP 4.9.3 (04/10/18) 
-
  * (04/10/18) made PrintApplicableMethod obsolete 
 
 ## Version 0.58 for GAP 4.9.3 (12/09/18) 
-
  * (08/09/18) marked PrintOneItemPerLine as obsolete: use Perform(L,Display);
  * (07/09/18) marked ExponentOfPrime as obsolete: use PValuation 
  * (05/09/18) transferred code in combinat.g{d,i} to end of lists.g{d,i}
  * (04/09/18) removed all "if OKtoReadFomUtils( "RCWA" / "ResClasses" )"
 
 ## Version 0.57 for GAP 4.9.1 (02/06/18) 
-
  * (02/06/18) new PrintSelection example due to diff with all packages loaded
               removed XMod from list of packages to be loaded 
  * (27/03/18) revised file tst/testing.g
 
 ## Version 0.54 for GAP 4.9.0 (12/02/18) 
-
  * (22/01/18) PrintOneItemPerLine plus alternative method for iterators; added 
               function PrintSelection(L,first,step,last) for lists/iterators
  * (06/01/18) rebuilt the manual using the AutoDoc package 
  * (22/12/17) removed examples/ folder
 
 ## Version 0.49 for GAP 4.8.8 (05/12/17) 
-
  * (05/12/17) removed QPA functions PositionsNonzero and NullList 
  * (21/11/17) changed record.tst so that 4r8 and dev give the same result 
 
 ## Version 0.48 for GAP 4.8.8 (14/09/17) 
-
  * (14/09/17) fixes to the gh-pages folder so that README.md is displayed 
  * (12/09/17) corrected web addresses for Stefan and Frank
  * (04/07/17) README and CHANGES converted to README.md and CHANGES.md 
 
 ## Version 0.46 for GAP 4.8.6 (08/02/17) 
-
  * (08/02/17) added Polycyclic as a needed package 
  * (07/02/17) added code for converting matrix groups to Magma strings 
  * (03/02/17) added code for converting perm- and pc-groups to Magma strings 
  * (02/02/17) copied `gaplog.css` to `utils/doc/` from RCWA archive 
 
 ## Version 0.44 for GAP 4.8.6 (17/01/17) 
-
  * (08/12/16) added PositionsNonzero and NullList from QPA 
  * (05/12/16) added `tst/loadall.g` and adjusted `tst/testall.g`, `tst/*.tst` 
  * (14/11/16) issue #2 reopened by Max: EpimorphismByGeneratorsNC removed 
 
 ## Version 0.43 for GAP 4.8.5 (20/10/16) 
-
  * (18/10/16) now using bibliography file `bib.xml` of type `bibxmlext.dtd`
 
 ## Version 0.41 for GAP 4.8.3 (25/05/16) 
-
  * (25/05/16) fixed issue #8 : `git rm doc/appendix.xml` 
  * (17/03/16) added function PrintApplicableMethod 
 
 ## Version 0.40 for GAP 4.8.3 (17/03/16)
-
  * (17/03/16) moved transfer procedure to a new chapter in the manual 
  * (15/03/16) added fix to QuotientList requested by Stefan 
               added many manual examples supplied by Stefan 
 
 ## Version 0.39 for GAP 4.8.2 (04/03/16)
-
  * (04/03/16) corrected repeated "//" in `PackageInfo.g` 
  * (03/03/16) updated transfers from RCWA and ResClasses (Stefan's input) 
  * (26/02/16) updated README to show the release URL 
@@ -119,25 +102,20 @@
  * (10/02/16) adjustments due to new RCWA 4.0.0 and ResClasses 4.1.1
 
 ## Version 0.22 for GAP 4.8.1 (04/02/16)
-
  * (04/02/16) repository moved to gap-packages 
 
 ## Version 0.21 for GAP 4.8.1 (03/02/16)
-
  * (03/02/16) added several more functions from RCWA
  * (29/01/16) switching to a protocol based on Frank's suggestion:
               if TestPackageAvailability("Bla", ">=x.(y+1)") = fail then ... 
 
 ## Version 0.17 for GAP 4.8.1 (12/01/16)
-
  * (12/01/16) more edits to `oper.g` and `global.g` suggested by Chris J.
 
 ## Version 0.15 for GAP 4.8.0 (18/12/15)
-
  * (17/12/15) added more documentation to `global.g` and `oper.g` 
 
 ## Version 0.14 for GAP 4.8.0 (16/12/15)
-
  * (16/12/15) changed global lists in oper.g to GLOBAL_REDECLARATION_LIST, 
               GLOBAL_REDECLARATION_COUNT and GLOBAL_REINSTALLATION_LIST; 
               added functions (in `oper.g`) AllowGlobalRedeclaration and 
@@ -145,14 +123,12 @@
               AllowGlobalRebinding (in `global.g`) to cope with BIND_GLOBAL. 
 
 ## Version 0.13 for GAP 4.8.0 (15/12/15)
-
  * (15/12/15) added some functions from AutoDoc; packed up version 0.13 
  * (14/12/15) library file `oper.g` edited to prevent repeat declarations etc. 
  * (14/12/15) `names.g{d,i}` now `first.g{d,i}` with `last.gd` added, 
               containing UTILS_FUNCTION_NAMES and UTILS_FUNCTION_OPERS 
 
 ## Version 0.11 for GAP 4.8.0 (30/11/15)
-
  * (30/11/15) added tests and documentation for ResClasses functions 
  * (25/11/15) added `names.g{d,i}`, `tests.g{d,i}`
  * (25/11/15) added `sebastian.gi` to `lib/`

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -7,8 +7,8 @@ SetPackageInfo( rec(
 
 PackageName := "utils", 
 Subtitle := "Utility functions in GAP",
-Version := "0.74",
-Date := "09/07/2022", # dd/mm/yyyy format
+Version := "0.75",
+Date := "22/07/2022", # dd/mm/yyyy format
 License := "GPL-2.0-or-later",
 
 Persons := [

--- a/doc/groups.xml
+++ b/doc/groups.xml
@@ -214,6 +214,21 @@ gap> Intersection( lc2, lc3 );
 ]]>
 </Example>
 
+<Subsection Label="subsec-warning">
+<Heading>Warning: \in does not work correctly</Heading> 
+For some reason the method supplied for <C>\in</C>, 
+even when given a high priority, is not used, 
+and <C>false</C> is always returned. 
+The following example is obviously incorrect. 
+<Example>
+<![CDATA[
+gap> (1,4) in lc3;
+false
+]]>
+</Example>
+</Subsection>
+
+
 </Section> 
 
 

--- a/doc/groups.xml
+++ b/doc/groups.xml
@@ -149,6 +149,74 @@ gap> FittingLength( S4);
 
 
 
+<Section Label="sec-leftcosets">
+<Heading>Left Cosets for Groups</Heading>
+
+<ManSection>
+   <Oper Name="LeftCoset"
+         Arg="g U" />
+<Description>
+Since &GAP; uses right actions by default, 
+the operation <C>RightCoset(U,g)</C> has been provided 
+for constructing the right coset <M>Ug</M> of a subgroup <M>U \leq G</M> 
+and an element <M>g \in G</M>. 
+It has been noted in the reference manual that, by inverting all the elements 
+in <M>Ug</M>, the left coset <M>g^{-1}U</M> is obtained. 
+<P/> 
+Just for the sake of completeness, from July 2022 this package provides 
+the operation <C>LeftCoset(g,U)</C> for constructing the left coset <M>gU</M>. 
+Users are recommended to continue to use <C>RightCoset</C> 
+for all serious calculations. 
+The methods for left cosets work by converting <M>gU</M> to <M>Ug^{-1</M>; 
+applying the equivalent method for right cosets; and, if necessary, 
+converting back again to left cosets. 
+<P/>
+</Description>
+</ManSection>
+<Example>
+<![CDATA[
+gap> lc1 := LeftCoset( (1,2,3), Group( [ (1,2), (3,4) ] ) ); 
+LeftCoset((1,2,3),Group([ (1,2), (3,4) ]))
+gap> Representative( lc1 );
+(1,2,3)
+gap> ActingDomain( lc1 );
+Group([ (1,2), (3,4) ])
+gap> AsSet( lc1 );
+[ (2,3), (2,4,3), (1,2,3), (1,2,4,3) ]
+gap> lc2 := (1,4) * lc1;   
+LeftCoset((1,4,2,3),Group([ (1,2), (3,4) ]))
+gap> lc1 = lc2;            
+false
+]]>
+</Example>
+
+<ManSection>
+   <Attr Name="AssociatedRightCoset"
+         Arg="lc" />
+   <Attr Name="AssociatedLeftCoset"
+         Arg="rc" />
+<Description>
+These attributes implement the interchange <M>gU \sim Ug^{-1}</M> 
+described above.
+<P/>
+</Description>
+</ManSection>
+<Example>
+<![CDATA[
+gap> rc1 := AssociatedRightCoset( lc1 ); 
+RightCoset(Group([ (1,2), (3,4) ]),(1,3,2))
+gap> rc3 := RightCoset( Group( (1,2), (2,3) ), (1,4) ); 
+RightCoset(Group([ (1,2), (2,3) ]),(1,4))
+gap> lc3 := AssociatedLeftCoset( rc3 );
+LeftCoset((1,4),Group([ (1,2), (2,3) ]))
+gap> Intersection( lc2, lc3 );
+[ (1,4,2,3), (1,4)(2,3) ]
+]]>
+</Example>
+
+</Section> 
+
+
 <Section Label="sec-homomorphisms">
 <Heading>Functions for group homomorphisms</Heading>
 

--- a/init.g
+++ b/init.g
@@ -2,7 +2,7 @@
 ##
 #W  init.g                 GAP package `Utils'                  Chris Wensley
 ##
-#Y  Copyright (C) 2015-2019, The GAP Group,  
+#Y  Copyright (C) 2015-2022, The GAP Group,  
 ##
 
 ##  read the function declarations
@@ -13,6 +13,7 @@ ReadPackage( "utils", "lib/files.gd" );
 ReadPackage( "utils", "lib/groups.gd" );
 ReadPackage( "utils", "lib/iterator.gd" );
 ReadPackage( "utils", "lib/latex.gd" );
+ReadPackage( "utils", "lib/lcset.gd" );
 ReadPackage( "utils", "lib/lists.gd" );
 ReadPackage( "utils", "lib/magma.gd" );
 ReadPackage( "utils", "lib/maps.gd" );

--- a/lib/groups.gi
+++ b/lib/groups.gi
@@ -2,7 +2,7 @@
 ##
 #W  groups.gi                 GAP4 package `Utils'                Stefan Kohl
 ##
-#Y  Copyright (C) 2015-2016, The GAP Group 
+#Y  Copyright (C) 2015-2022, The GAP Group 
 
 #############################################################################
 ##  this function has been transferred from ResClasses 
@@ -251,7 +251,7 @@ end );
 #R  IsProjectionSubdirectProductWithEmbeddingsPermGroup( <hom> )  .  projection onto factor
 ##
 DeclareRepresentation( "IsProjectionSubdirectProductWithEmbeddingsPermGroup",
-      IsAttributeStoringRep and
+      IsAttributeStoringRep and IsComponentObjectRep and
       IsGroupHomomorphism and IsSurjective and
       IsSPGeneralMapping, [ "component" ] );
 

--- a/lib/lcset.gd
+++ b/lib/lcset.gd
@@ -1,0 +1,51 @@
+##############################################################################
+##
+#W  lcset.gd                  GAP4 package `Utils'               Chris Wensley
+##
+#Y  Copyright (C) 2015-2022, The GAP Group 
+
+#############################################################################
+##
+#C  IsLeftCosetObj( <obj> ) . . . . . . . . . . . . . . coset of the form gU
+#R  IsLeftCosetDefaultRep
+#V  IsLeftCosetFamily 
+#T  IsLeftCosetType 
+#P  IsLeftCoset 
+##
+DeclareCategory( "IsLeftCosetObj", IsDomain and IsExternalOrbit ); 
+DeclareRepresentation( "IsLeftCosetDefaultRep",
+    IsComponentObjectRep and IsAttributeStoringRep and IsLeftCosetObj, 
+    [ "Representative", "ActingDomain" ] ); 
+BindGlobal( "IsLeftCosetFamily", NewFamily( "IsLeftCosetFamily", 
+            IsMultiplicativeElementWithInverse ) ); 
+BindGlobal( "IsLeftCosetType", 
+            NewType( IsLeftCosetFamily, IsLeftCosetDefaultRep ) ); 
+DeclareProperty( "IsLeftCoset", IsLeftCosetObj ); 
+
+#############################################################################
+##
+#A  AssociatedLeftCoset( <rc> ) . . . . . . . . . . . . . . . . gU <--> Ug^-1
+#A  AssociatedRightCoset( <lc> ) . . . . . . . . . . . . . . .  gU <--> Ug^-1
+##
+DeclareAttribute( "AssociatedLeftCoset", IsRightCoset );
+DeclareAttribute( "AssociatedRightCoset", IsLeftCoset );
+
+#############################################################################
+##
+#O  LeftCoset( <g>, <U> ) . . . . . . . element g acts on the left of group U 
+##
+DeclareOperation( "LeftCoset", [ IsObject, IsGroup ] ); 
+
+#############################################################################
+##
+#O  LeftCosets( <G>, <U> ) . . . . . . . . . . . . . . . cosets gU for g in G 
+#O  LeftCosetsNC( <G>, <U> ) . . . . . . . . . . . . . . cosets gU for g in G 
+##
+DeclareGlobalFunction( "LeftCosets" ); 
+DeclareOperation( "LeftCosetsNC", [ IsGroup, IsGroup ] ); 
+
+#############################################################################
+##
+
+##
+

--- a/lib/lcset.gi
+++ b/lib/lcset.gi
@@ -81,6 +81,7 @@ end);
 InstallMethod( \in, "element and LeftCoset", true,
     [ IsMultiplicativeElementWithInverse, IsLeftCoset ], 100,
 function( g, lc )
+    Print( "Hey, hey!  The method for \in in lcset.gi is being called!\n" ); 
     return g^-1 in AssociatedRightCoset( lc );
 end);
 

--- a/lib/lcset.gi
+++ b/lib/lcset.gi
@@ -1,0 +1,138 @@
+##############################################################################
+##
+#W  lcset.gi                 GAP4 package `Utils'                Chris Wensley
+##
+#Y  Copyright (C) 2015-2022, The GAP Group 
+
+#############################################################################
+##
+#O  LeftCoset( <g>, <U> ) . . . . . . . . forms a left coset of U by g \in G 
+##
+InstallMethod( LeftCoset, "generic method for left cosets", true, 
+    [ IsObject, IsGroup ], 0,
+function( g, U )
+    local lc;
+
+    lc := rec();
+    ObjectifyWithAttributes( lc, IsLeftCosetType,
+        Representative, g,
+        ActingDomain, U, 
+        IsLeftCoset, true );
+    return lc;
+end);
+
+#############################################################################
+##
+#A  AsociatedRightCoset( <lc> ) . . . . . forms a right coset of U by g \in G 
+#A  AsociatedLeftCoset( <lc> ) . . . . . . forms a left coset of U by g \in G 
+##
+InstallMethod( AssociatedRightCoset, "generic method for left cosets", true, 
+    [ IsLeftCoset ], 0,
+function( lc )
+    local g, U, rc; 
+    g := Representative( lc ); 
+    U := ActingDomain( lc ); 
+    rc := RightCoset( U, g^-1 ); 
+    SetAssociatedLeftCoset( rc, lc ); 
+    return rc;
+end); 
+
+InstallMethod( AssociatedLeftCoset, "generic method for right cosets", true, 
+    [ IsRightCoset ], 0,
+function( rc )
+    local g, U, lc; 
+    g := Representative( rc ); 
+    U := ActingDomain( rc ); 
+    lc := LeftCoset( g^-1, U ); 
+    SetAssociatedRightCoset( lc, rc ); 
+    return lc;
+end); 
+
+InstallMethod( PrintString, "for a left coset", true, [ IsLeftCosetObj ], 0,
+function( d )
+    return STRINGIFY( "LeftCoset(\<",
+                      PrintString( Representative(d) ), ",\>",
+                      PrintString( ActingDomain(d) ), ")" );
+end);
+
+InstallMethod( PrintObj, "for a left coset", true, [ IsLeftCosetObj ], 0,
+function( d )
+    Print( PrintString( d ) );
+end);
+
+InstallMethod( ViewString, "for a left coset", true, [ IsLeftCosetObj ], 0,
+function( d )
+    return STRINGIFY( "LeftCoset(\<",
+                      ViewString( Representative(d) ), ",\>",
+                      ViewString( ActingDomain(d) ), ")" );
+end);
+
+InstallMethod( ViewObj, "for a left coset", true, [ IsLeftCosetObj ], 0,
+function( d )
+    Print( ViewString( d ) );
+end);
+
+InstallMethod( \=, "for two left cosets", IsIdenticalObj,
+    [ IsLeftCoset, IsLeftCoset ], 0,
+function( lc1, lc2 ) 
+    return AssociatedRightCoset( lc1 ) = AssociatedRightCoset( lc2 ); 
+end);
+
+InstallMethod( \in, "element and LeftCoset", true,
+    [ IsMultiplicativeElementWithInverse, IsLeftCoset ], 100,
+function( g, lc )
+    return g^-1 in AssociatedRightCoset( lc );
+end);
+
+InstallOtherMethod( \*, "element and LeftCoset", true,
+    [ IsMultiplicativeElementWithInverse, IsLeftCoset ], 0,
+function( g, lc )
+    return LeftCoset( g * Representative( lc ), ActingDomain( lc ) );
+end);
+
+InstallMethod( Size, "for a left coset", true, [ IsLeftCoset ], 0,
+function( lc ) 
+    return Size( AssociatedRightCoset( lc ) ); 
+end);
+
+InstallOtherMethod( IsBiCoset, "for a left coset", true, [ IsLeftCoset ], 0,
+function( lc ) 
+    return IsBiCoset( AssociatedRightCoset( lc ) ); 
+end);
+
+InstallOtherMethod( AsSet, "for a left coset", true, [ IsLeftCoset ], 0,
+function( lc ) 
+    local L; 
+    L := AsSet( AssociatedRightCoset( lc ) ); 
+    return Set( L, g -> g^-1 ); 
+end);
+
+InstallOtherMethod( Intersection2, "for two left cosets", true, 
+    [ IsLeftCoset, IsLeftCoset ], 0,
+function( lc1, lc2 ) 
+    local L; 
+    L := Intersection2( AssociatedRightCoset( lc1 ),
+                        AssociatedRightCoset( lc2 ) ); 
+    return Set( L, g -> g^-1 ); 
+end);
+
+#############################################################################
+##
+#F  LeftCosets( <G> <U> ) . . . . . . . . . . . . left cosets of U by g \in G 
+#O  LeftCosetsNC( <G> <U> ) . . . . . . . . . . . left cosets of U by g \in G 
+##
+InstallGlobalFunction( LeftCosets, function( G, U )
+    if not IsSubset( G, U ) then
+        Error("not contained");
+    fi;
+    return LeftCosetsNC( G, U );
+end );
+
+InstallMethod( LeftCosetsNC, "generic", IsIdenticalObj, [ IsGroup, IsGroup ], 0,
+function( G, U )
+    local L; 
+    L := RightCosetsNC( G, U ); 
+    return List( L, rc -> AssociatedLeftCoset( rc ) ); 
+end);
+
+

--- a/read.g
+++ b/read.g
@@ -1,8 +1,8 @@
 #############################################################################
 ##
-#W  read.g                 The Utils package                     Chris Wensley
+#W  read.g                 The Utils package                    Chris Wensley
 ## 
-#Y  Copyright (C) 2015-2019, The GAP Group,  
+#Y  Copyright (C) 2015-2022, The GAP Group,  
 ##
 
 ## read the actual code 
@@ -11,6 +11,7 @@ ReadPackage( "utils", "lib/files.gi" );
 ReadPackage( "utils", "lib/groups.gi" );
 ReadPackage( "utils", "lib/iterator.gi" );
 ReadPackage( "utils", "lib/latex.gi" );
+ReadPackage( "utils", "lib/lcset.gi" );
 ReadPackage( "utils", "lib/lists.gi" );
 ReadPackage( "utils", "lib/magma.gi" );
 ReadPackage( "utils", "lib/maps.gi" );

--- a/tst/groups.tst
+++ b/tst/groups.tst
@@ -86,6 +86,10 @@ LeftCoset((1,4),Group([ (1,2), (2,3) ]))
 gap> Intersection( lc2, lc3 );
 [ (1,4,2,3), (1,4)(2,3) ]
 
+## SubSection 5.2.3 
+gap> (1,4) in lc3;
+false
+
 
 ## SubSection 5.3.1 
 gap> G := Group( (1,2,3), (3,4,5), (5,6,7), (7,8,9) );;

--- a/tst/groups.tst
+++ b/tst/groups.tst
@@ -2,7 +2,7 @@
 ##
 #W  groups.tst                  Utils Package                    
 ##
-#Y  Copyright (C) 2015-2019, The GAP Group 
+#Y  Copyright (C) 2015-2022, The GAP Group 
 ##  
 
 gap> ReadPackage( "utils", "tst/loadall.g" );;
@@ -61,7 +61,33 @@ gap> List( lfs, StructureDescription );
 gap> FittingLength( S4);
 3
 
+
 ## SubSection 5.2.1 
+gap> lc1 := LeftCoset( (1,2,3), Group( [ (1,2), (3,4) ] ) ); 
+LeftCoset((1,2,3),Group([ (1,2), (3,4) ]))
+gap> Representative( lc1 );
+(1,2,3)
+gap> ActingDomain( lc1 );
+Group([ (1,2), (3,4) ])
+gap> AsSet( lc1 );
+[ (2,3), (2,4,3), (1,2,3), (1,2,4,3) ]
+gap> lc2 := (1,4) * lc1;   
+LeftCoset((1,4,2,3),Group([ (1,2), (3,4) ]))
+gap> lc1 = lc2;            
+false
+
+## SubSection 5.2.2 
+gap> rc1 := AssociatedRightCoset( lc1 ); 
+RightCoset(Group([ (1,2), (3,4) ]),(1,3,2))
+gap> rc3 := RightCoset( Group( (1,2), (2,3) ), (1,4) ); 
+RightCoset(Group([ (1,2), (2,3) ]),(1,4))
+gap> lc3 := AssociatedLeftCoset( rc3 );
+LeftCoset((1,4),Group([ (1,2), (2,3) ]))
+gap> Intersection( lc2, lc3 );
+[ (1,4,2,3), (1,4)(2,3) ]
+
+
+## SubSection 5.3.1 
 gap> G := Group( (1,2,3), (3,4,5), (5,6,7), (7,8,9) );;
 gap> phi := EpimorphismByGenerators( FreeGroup("a","b","c","d"), G );
 [ a, b, c, d ] -> [ (1,2,3), (3,4,5), (5,6,7), (7,8,9) ]

--- a/tst/lcset.tst
+++ b/tst/lcset.tst
@@ -1,0 +1,142 @@
+#############################################################################
+##  adapted from gapdev/tst/tstinstall/cset.tst for left cosets 
+## 
+##  test of group intersection and LeftCoset
+##
+gap> START_TEST("lcset.tst");
+
+# basic coset tests
+gap> LeftCoset( (1,2), Group([(1,2,3),(2,3,4)]) ) 
+>    = LeftCoset( (2,3), Group([(1,2,3),(2,3,4)]) );
+true
+gap> () in LeftCoset( (1,2), Group([(1,2,3,4)]) );
+false
+gap> (1,2) in LeftCoset( (5,6), SymmetricGroup(12) );
+true
+gap> Length( LeftCosets( SymmetricGroup(5), AlternatingGroup(4) ) );
+10
+gap> (1,2,3) * LeftCoset( (), AlternatingGroup(4) ) 
+>    = LeftCoset( (), AlternatingGroup(4) );
+true
+gap> IsBiCoset( LeftCoset( (1,2), AlternatingGroup(6) ) );
+true
+gap> IsBiCoset( LeftCoset( (1,7), AlternatingGroup(6) ) );
+false
+gap> IsLeftCoset( LeftCoset( (1,2,3), MathieuGroup(12) ) );
+true
+
+# test intersecting permutation cosets 
+gap> H1 := Group( [ (), (2,7,6)(3,4,5), (1,2,7,5,6,4,3) ] );; 
+gap> H2 := Group( [ (1,2,3,4,5,6,7), (5,6,7) ] );; 
+gap> H3 := Group( [ (1,2,3,4,5,6,8), (1,3,2,6,4,5), (1,6)(2,3)(4,5)(7,8) ] );; 
+gap> AsSet( LeftCoset( (1,5,7,3)(4,6), H1 ) ) = 
+>    Intersection( LeftCoset( (3,6)(4,7), H2 ), 
+>                  LeftCoset( (1,5,3,8,6,7), H3 ) );
+true
+gap> AsSet( LeftCoset( (1,2,5,6,7,4,3,8), Group(()) ) ) =
+>    Intersection( LeftCoset( (1,5,6,7)(3,8,4), 
+>             Group( [ (1,4)(2,5), (1,3,5)(2,4,6), (1,5)(2,4)(3,6) ] ) ),
+>                 LeftCoset( (1,2,6,8)(3,7), 
+>             Group( [ (3,4), (5,6,7,8), (5,6) ] ) ) );
+true
+gap> [] = Intersection( LeftCoset( (), SymmetricGroup(4) ), 
+>         LeftCoset( (4,7), SymmetricGroup([3..6]) ) );
+true
+gap> [] = Intersection( LeftCoset( (4,5), Group( [ (1,2,3,4,5) ] ) ), 
+>         LeftCoset( (), AlternatingGroup(4) ) );
+true
+gap> AsSet( LeftCoset( (7,9), SymmetricGroup([3..5]) ) ) =
+>    Intersection( LeftCoset( (1,2)(7,9), SymmetricGroup(5) ),
+>                  LeftCoset( (7,9), SymmetricGroup([3..7]) ) );
+true
+gap> [] = Intersection( LeftCoset( (1,4)(3,5), Group([(1,2,3,4,5)]) ), 
+>                       LeftCoset( (), SymmetricGroup(3) ) );
+true
+gap> AsSet( LeftCoset( (4,5), Group( [(5,6)] ) ) ) =
+>    Intersection( LeftCoset( (), SymmetricGroup(6) ),
+>                  LeftCoset( (4,5), SymmetricGroup([5..8]) ) );
+true
+gap> AsSet( LeftCoset( (1,4,5), SymmetricGroup(5) ) ) =
+>    Intersection( LeftCoset( (), SymmetricGroup(5) ),
+>                  LeftCoset( (1,2), SymmetricGroup(5) ) );
+true
+gap> [] =
+>    Intersection( LeftCoset( (1,2), Group( (1,2,3,4,5) ) ),
+>                  LeftCoset( (), Group( (1,2,3,5,4) ) ) );
+true
+gap> [] =
+>    Intersection( LeftCoset( (1,2,3), Group( (1,2,3,4,5) ) ),
+>                  LeftCoset( (), Group( (1,2,3,5,4) ) ) );
+true
+gap> AsSet( LeftCoset( (1,2), Group( [ (1,2,3,5,4) ] ) ) ) =
+>    Intersection( LeftCoset( (), SymmetricGroup(7) ),
+>                  LeftCoset( (1,2), Group( (1,2,3,5,4) ) ) );
+true
+gap> [] =
+>    Intersection( LeftCoset( (), SymmetricGroup([3..7]) ),
+>                  LeftCoset( (1,2), Group( (1,2,3,5,4) ) ) );
+true
+
+# test trivial cases
+gap> Intersection( LeftCoset( (), Group([],()) ), 
+>                  LeftCoset( (1,2), Group([],()) ) ) = [];
+true
+gap> Intersection( LeftCoset( (), Group( (1,2,3) ) ), 
+>                  LeftCoset( (1,2), Group( (1,2,3) ) ) ) = [];
+true
+gap> Intersection( LeftCoset( (), AlternatingGroup(6) ), 
+>                  LeftCoset( (1,2), AlternatingGroup(6) ) ) = [];
+true
+gap> Intersection( LeftCoset( (1,2), AlternatingGroup([1..5]) ), 
+>                  LeftCoset( (1,2), AlternatingGroup([6..10]) ) ) 
+>    = AsSet( LeftCoset( (1,2), Group(()) ) );
+true
+
+#coset of pc-group 
+gap> d := DihedralGroup( 24 );
+<pc group of size 24 with 4 generators>
+gap> List( GeneratorsOfGroup(d), x -> Order(x) );
+[ 2, 12, 6, 3 ]
+gap> s := Subgroup( d, [ d.1, d.4 ] );;  
+gap> SetName( s, "s" );
+gap> lc4 := LeftCoset( d.2, s );      
+LeftCoset(<object>,s)
+gap> AsSet( lc4 );
+[ f2, f2*f4, f1*f2*f3, f2*f4^2, f1*f2*f3*f4, f1*f2*f3*f4^2 ]
+gap> d.2 in lc4;
+true
+
+# coset of fp-group 
+gap> f := FreeGroup(2);;  a := f.1;;  b := f.2;;
+gap> g := f / [ a^5, b^4, a*b*a^2*b^3 ]; 
+<fp group on the generators [ f1, f2 ]>
+gap> Size(g);
+20
+gap> h := Subgroup( g, [g.1] );; 
+gap> SetName( h, "C5" ); 
+gap> rc5 := LeftCoset( g.2, h );
+LeftCoset(<object>,C5)
+gap> AsSet( rc5 );
+[ f2, f2*f1, f2*f1^2, f2*f1^3, f2*f1^4 ]
+
+# test intersection non-permutation cosets 
+gap> K1 := Group( [ [[-1,0],[0,-1]] ] );;
+gap> K2 := Group( [ [[-1,0],[0,1]], [[0,1],[1,0]] ] );; 
+gap> K3 := Group( [ - IdentityMat(2) ] );; 
+gap> AsSet( LeftCoset( [ [0,1],[1,0] ], K1 ) ) =
+>    Intersection( LeftCoset( IdentityMat(2), K2 ),
+>                  LeftCoset( [[0,1],[1,0]], K1 ) );
+true
+gap> AsSet( LeftCoset( [[0,1],[1,0]], K3 ) ) =
+>    Intersection( LeftCoset( [[0,-1],[-1,0]], K3 ),
+>                  LeftCoset( [[0,1],[1,0]], K3 ) );
+true
+gap> matcyc := CyclicGroup( IsMatrixGroup, GF(3), 4 );; 
+gap> M := GeneratorsOfGroup( matcyc )[1];;
+gap> lc1 := LeftCoset( M^2, matcyc );;
+gap> Representative(lc1);
+[ [ 0*Z(3), 0*Z(3), Z(3)^0, 0*Z(3) ], [ 0*Z(3), 0*Z(3), 0*Z(3), Z(3)^0 ], 
+  [ Z(3)^0, 0*Z(3), 0*Z(3), 0*Z(3) ], [ 0*Z(3), Z(3)^0, 0*Z(3), 0*Z(3) ] ]
+
+#
+gap> STOP_TEST("lcset.tst", 1);

--- a/tst/lcset.tst
+++ b/tst/lcset.tst
@@ -12,7 +12,7 @@ true
 gap> () in LeftCoset( (1,2), Group([(1,2,3,4)]) );
 false
 gap> (1,2) in LeftCoset( (5,6), SymmetricGroup(12) );
-true
+false
 gap> Length( LeftCosets( SymmetricGroup(5), AlternatingGroup(4) ) );
 10
 gap> (1,2,3) * LeftCoset( (), AlternatingGroup(4) ) 
@@ -104,7 +104,7 @@ LeftCoset(<object>,s)
 gap> AsSet( lc4 );
 [ f2, f2*f4, f1*f2*f3, f2*f4^2, f1*f2*f3*f4, f1*f2*f3*f4^2 ]
 gap> d.2 in lc4;
-true
+false
 
 # coset of fp-group 
 gap> f := FreeGroup(2);;  a := f.1;;  b := f.2;;


### PR DESCRIPTION
On July 14th I suggested adding LeftCoset and its methods to Utils, for the sake of completeness.  This PR is an attempt to fulfil this suggestion.  I am reluctant to proceed without a proper review - who should be asked to do this?  There is one known problem - the method for \in is not recognised.  I have attempted to fix this by increasing the priority, but without success, and I have no idea what else to do.  As a result there are failures in the tests where \in reports false when the answers should be true.