### PR TITLE
Add a missing right curly brace to groups.xml

### DIFF
--- a/doc/groups.xml
+++ b/doc/groups.xml
@@ -167,7 +167,7 @@ Just for the sake of completeness, from July 2022 this package provides
 the operation <C>LeftCoset(g,U)</C> for constructing the left coset <M>gU</M>. 
 Users are recommended to continue to use <C>RightCoset</C> 
 for all serious calculations. 
-The methods for left cosets work by converting <M>gU</M> to <M>Ug^{-1</M>; 
+The methods for left cosets work by converting <M>gU</M> to <M>Ug^{-1}</M>;
 applying the equivalent method for right cosets; and, if necessary, 
 converting back again to left cosets. 
 <P/>


### PR DESCRIPTION
Resolves this LaTeX warning:
```
! Missing } inserted.
<inserted text> 
                }
l.990 ...osets work by converting $gU$ to $Ug^{-1$
                                                  ; applying the equivalent ...
I've inserted something that you may have forgotten.
(See the <inserted text> above.)
With luck, this will get me unwedged. But if you
really didn't forget anything, try typing `2' now; then
my insertion and my current dilemma will both disappear.
```
