### PR TITLE
first attempt to provide `Download`

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -7,7 +7,7 @@ SetPackageInfo( rec(
 
 PackageName := "utils", 
 Subtitle := "Utility functions in GAP",
-Version := "0.76",
+Version := "0.77",
 Date := "06/08/2022", # dd/mm/yyyy format
 License := "GPL-2.0-or-later",
 
@@ -112,7 +112,7 @@ Dependencies := rec(
   NeededOtherPackages := [ [ "AutoDoc", ">= 2020.08.11" ], 
                            [ "GAPDoc", ">= 1.6.4" ], 
                            [ "polycyclic", ">= 2.16" ] ], 
-  SuggestedOtherPackages := [ ],
+  SuggestedOtherPackages := [ [ "curlInterface", ">= 2.3.0" ] ],
   ExternalConditions := [ ]
 ),
 

--- a/doc/download.xml
+++ b/doc/download.xml
@@ -37,7 +37,7 @@ the returned record does not have a <C>result</C> component in this case.
 <P/>
 <Example>
 <![CDATA[
-gap> url:= "https://github.com/gap-packages/utils/README.md";;
+gap> url:= "https://www.gap-system.org/Packages/utils.html";;
 gap> res:= Download( url );;
 gap> res.success;
 true

--- a/doc/download.xml
+++ b/doc/download.xml
@@ -52,6 +52,11 @@ The following components are supported.
   If this component is bound and has the value <K>false</K>
   then those download methods that are based on <C>curl</C> or <C>wget</C>
   will omit the check of the server's certificate.
+
+  The same effect is achieved for all <Ref Func="Download"/> calls
+  by setting the user preference <C>DownloadVerifyCertificate</C>
+  (see <Ref Subsect="subsec-DownloadVerifyCertificate"/>) to <K>false</K>
+  and omitting the <C>verifyCert</C> component from <A>opt</A>.
 </Item>
 </List>
 <P/>
@@ -72,6 +77,26 @@ true
 </Example>
 </Description>
 </ManSection>
+
+<Subsection Label="subsec-DownloadVerifyCertificate">
+<Heading>User preference <C>DownloadVerifyCertificate</C></Heading>
+<Index Key="DownloadVerifyCertificate"><C>DownloadVerifyCertificate</C></Index>
+
+The value <K>true</K> (the default) means that the server's certificate
+is checked in calls of <Ref Func="Download"/>,
+such that nothing gets downloaded if the certificate is invalid.
+
+If the value is <K>false</K> then those download methods that are based on
+<C>curl</C> or <C>wget</C> will omit the check of the server's certificate.
+
+One can set the value of the preference to <C>val</C> via
+<Ref Func="SetUserPreference" BookName="ref"/>, by calling
+<C>SetUserPreference( "utils", "DownloadVerifyCertificate", val )</C>,
+and access the current value via 
+<Ref Func="UserPreference" BookName="ref"/>, by calling
+<C>UserPreference( "utils", "DownloadVerifyCertificate" )</C>.
+
+</Subsection>
 
 </Section>
 

--- a/doc/download.xml
+++ b/doc/download.xml
@@ -85,16 +85,23 @@ true
 The value <K>true</K> (the default) means that the server's certificate
 is checked in calls of <Ref Func="Download"/>,
 such that nothing gets downloaded if the certificate is invalid.
-
-If the value is <K>false</K> then those download methods that are based on
-<C>curl</C> or <C>wget</C> will omit the check of the server's certificate.
-
+<P/>
+If the value is <K>false</K> then download methods are supposed to omit
+the check of the server's certificate (this may not be supported by all
+download methods).
+<P/>
 One can set the value of the preference to <C>val</C> via
 <Ref Func="SetUserPreference" BookName="ref"/>, by calling
 <C>SetUserPreference( "utils", "DownloadVerifyCertificate", val )</C>,
 and access the current value via 
 <Ref Func="UserPreference" BookName="ref"/>, by calling
 <C>UserPreference( "utils", "DownloadVerifyCertificate" )</C>.
+<P/>
+We recommend leaving this preference at its default value <K>true</K>.
+But sometimes it can be necessary to change it, e.g. to work around issues
+with old operating systems which may not be able to correctly verify new
+certificates. In general it is better to update such a system, but if that is
+not an option, then disabling certificate checks may be a good last resort.
 
 </Subsection>
 

--- a/doc/download.xml
+++ b/doc/download.xml
@@ -50,10 +50,8 @@ The following components are supported.
 <Mark><C>verifyCert</C></Mark>
 <Item>
   If this component is bound and has the value <K>false</K>
-  then those download methods that are based on <C>curl</C> will
-  omit the check of the server's certificate,
-  by calling <C>curl</C> with the <C>-k</C> option or setting the
-  <C>libcurl</C> option <C>CURLOPT_SSL_VERIFYPEER</C> to <C>0</C>.
+  then those download methods that are based on <C>curl</C> or <C>wget</C>
+  will omit the check of the server's certificate.
 </Item>
 </List>
 <P/>

--- a/doc/download.xml
+++ b/doc/download.xml
@@ -29,11 +29,33 @@ whose value is a string that contains the contents of the downloaded file.
 In the latter case, the component <C>error</C> is bound,
 whose value is a string that describes the problem.
 <P/>
+The function calls the methods stored in the global list
+<C>Download_Methods</C> until one of them is successful.
+Currently there are methods based on the &GAP; functions
+<Ref Func="DownloadURL" BookName="curl"/> and
+<Ref Func="SingleHTTPRequest" BookName="io"/>,
+and methods based on the external programs <C>wget</C> and <C>curl</C>.
+<P/>
 An optional record <A>opt</A> can be given.
-If the component <C>target</C> is bound in <A>opt</A> then
-its value must be a string that is a local filename,
-and the function writes the downloaded contents to this file;
-the returned record does not have a <C>result</C> component in this case.
+The following components are supported.
+<P/>
+<List>
+<Mark><C>target</C></Mark>
+<Item>
+  If this component is bound then its value must be a string
+  that is a local filename,
+  and the function writes the downloaded contents to this file;
+  the returned record does not have a <C>result</C> component in this case.
+</Item>
+<Mark><C>verifyCert</C></Mark>
+<Item>
+  If this component is bound and has the value <K>false</K>
+  then those download methods that are based on <C>curl</C> will
+  omit the check of the server's certificate,
+  by calling <C>curl</C> with the <C>-k</C> option or setting the
+  <C>libcurl</C> option <C>CURLOPT_SSL_VERIFYPEER</C> to <C>0</C>.
+</Item>
+</List>
 <P/>
 <Example>
 <![CDATA[

--- a/doc/download.xml
+++ b/doc/download.xml
@@ -1,0 +1,58 @@
+<!-- ------------------------------------------------------------------- -->
+<!--                                                                     -->
+<!--  download.xml            Utils documentation                        -->
+<!--                                                                     -->
+<!--  Copyright (C) 2022, The GAP Group                                  --> 
+<!--                                                                     -->
+<!-- ------------------------------------------------------------------- -->
+
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Chapter Label="chap-download">
+<Heading>Web Downloads</Heading>
+
+<Section Label="sec-download">
+<Heading>Functions for downloading files from the web</Heading>
+
+<ManSection>
+<Func Name="Download" Arg="url[, opt]" />
+
+<Description>
+This function downloads the file with the web address <A>url</A>,
+which must be a string.
+<P/>
+The result is a record which has at least the component <C>success</C>,
+with value <K>true</K> if the download was successful and <K>false</K>
+otherwise.
+In the former case, the component <C>result</C> is bound,
+whose value is a string that contains the contents of the downloaded file.
+In the latter case, the component <C>error</C> is bound,
+whose value is a string that describes the problem.
+<P/>
+An optional record <A>opt</A> can be given.
+If the component <C>target</C> is bound in <A>opt</A> then
+its value must be a string that is a local filename,
+and the function writes the downloaded contents to this file;
+the returned record does not have a <C>result</C> component in this case.
+<P/>
+<Example>
+<![CDATA[
+gap> url:= "https://github.com/gap-packages/utils/README.md";;
+gap> res:= Download( url );;
+gap> res.success;
+true
+gap> IsBound( res.result ) and IsString( res.result );
+true
+gap> res:= Download( Concatenation( url, "xxx" ) );;
+gap> res.success;
+false
+gap> IsBound( res.error ) and IsString( res.error );
+true
+]]>
+</Example>
+</Description>
+</ManSection>
+
+</Section>
+
+</Chapter>

--- a/init.g
+++ b/init.g
@@ -21,3 +21,4 @@ ReadPackage( "utils", "lib/number.gd" );
 ReadPackage( "utils", "lib/print.gd" );
 ReadPackage( "utils", "lib/record.gd" );
 ReadPackage( "utils", "lib/string.gd" );
+ReadPackage( "utils", "lib/download.gd" );

--- a/lib/download.gd
+++ b/lib/download.gd
@@ -14,3 +14,23 @@
 DeclareOperation( "Download", [ IsString ] );
 DeclareOperation( "Download", [ IsString, IsRecord ] );
 
+
+#############################################################################
+##
+#U  DownloadVerifyCertificate
+##
+DeclareUserPreference( rec(
+  name:= "DownloadVerifyCertificate",
+  description:= [
+    "The value 'true' (the default) means that the server's certificate \
+is checked in calls of 'Download' such that nothing gets downloaded \
+if the certificate is invalid. \
+If the value is 'false' then those download methods that are based on \
+curl or wget will omit the check of the server's certificate."
+    ],
+  default:= true,
+  values:= [ true, false ],
+  multi:= false,
+  package:= "utils",
+  ) );
+

--- a/lib/download.gd
+++ b/lib/download.gd
@@ -1,0 +1,16 @@
+##############################################################################
+##
+#W  download.gd                 GAP4 package `Utils'             Thomas Breuer
+##
+#Y  Copyright (C) 2022, The GAP Group
+
+#############################################################################
+##  This function is intended to be used instead of similar ones from
+##  various packages (AtlasRep, FactInt, GAPDoc, PackageManager,
+##  StandardFF, ...)
+##  
+#O  Download( <url>[, <opt>] ) 
+##  
+DeclareOperation( "Download", [ IsString ] );
+DeclareOperation( "Download", [ IsString, IsRecord ] );
+

--- a/lib/download.gd
+++ b/lib/download.gd
@@ -8,9 +8,9 @@
 ##  This function is intended to be used instead of similar ones from
 ##  various packages (AtlasRep, FactInt, GAPDoc, PackageManager,
 ##  StandardFF, ...)
-##  
-#O  Download( <url>[, <opt>] ) 
-##  
+##
+#O  Download( <url>[, <opt>] )
+##
 DeclareOperation( "Download", [ IsString ] );
 DeclareOperation( "Download", [ IsString, IsRecord ] );
 

--- a/lib/download.gi
+++ b/lib/download.gi
@@ -179,6 +179,12 @@ InstallMethod( Download,
     function( url, opt )
     local errors, r, res;
 
+    # Set the default for 'verifyCert' if necessary.
+    if not IsBound( opt.verifyCert ) and
+       UserPreference( "utils", "DownloadVerifyCertificate" ) = false then
+      opt.verifyCert:= false;
+    fi;
+
     # Run over the methods.
     errors:= [];
     for r in Download_Methods do

--- a/lib/download.gi
+++ b/lib/download.gi
@@ -5,13 +5,8 @@
 #Y  Copyright (C) 2022, The GAP Group
 
 #############################################################################
-##  
-#M  Download( <url>[, <opt>] ) 
-##  
-##  Try to download the file described by the string <url>,
-##  and return a record with the components 'success' ('true' or 'false'),
-##  and 'result' (a string, only if 'success' is 'true'),
-##  and 'error' (a string, only if 'success' is 'false').
+##
+#V  Download_Methods
 ##
 ##  Use the following tools (in this order).
 ##
@@ -21,7 +16,140 @@
 ##    then call the 'SingleHTTPRequest' function from this package.
 ##  - If a 'wget' executable is available then call it.
 ##  - If a 'curl' executable is available then call it.
-##  
+##
+##  Note that currently the methods are *NOT* consistent in the case of
+##  failures:
+##
+##  - The function 'DownloadURL' does not admit specifying that error codes
+##    >= 400 are regarded as failures.
+##    ('CURLOPT_FAILONERROR' cannot be set via the GAP interface.)
+##    If one asks for a nonexisting file then the "via CurlInterface" method
+##    returns a record in which 'success' is set to 'true',
+##    and 'result' explains the problem.
+##    The other methods set 'success' to 'false'.
+##
+##  - The function 'SingleHTTPRequest' does not regard the error code 301
+##    as failure.
+##    This happens for example if one asks for the file at
+##    'http://www.gap-system.org/Packages/utils.html'.
+##
+BindGlobal( "Download_Methods", [] );
+
+Add( Download_Methods, rec(
+  name:= "via CurlInterface",
+  isAvailable:= {} -> IsBoundGlobal( "DownloadURL" ),
+  download:= function( url, target )
+    local res;
+
+    res:= ValueGlobal( "DownloadURL" )( url );
+    if target <> fail then
+      FileString( target, res.result );
+      Unbind( res.result );
+    fi;
+    return res;
+  end ) );
+
+Add( Download_Methods, rec(
+  name:= "via SingleHTTPRequest",
+  isAvailable:= {} -> IsBoundGlobal( "SingleHTTPRequest" ),
+  download:= function( url, target )
+    local rurl, pos, domain, uri, res;
+
+    if not StartsWith( url, "http://" ) then
+      return rec( success:= false, error:= "protocol is not http" );
+    fi;
+
+    rurl:= ReplacedString( url, "http://", "" );
+    pos:= Position( rurl, '/' );
+    domain:= rurl{ [ 1 .. pos-1 ] };
+    uri:= rurl{ [ pos .. Length( rurl ) ] };
+    if target = fail then
+      res:= ValueGlobal( "SingleHTTPRequest" )( domain, 80, "GET", uri, rec(), false, false );
+    else
+      res:= ValueGlobal( "SingleHTTPRequest" )( domain, 80, "GET", uri, rec(), false, target );
+    fi;
+    if res.statuscode >= 400 then
+      return rec( success:= false,
+                  error:= Concatenation( "HTTP error code ", res.statuscode ) );
+    elif target <> fail then
+      return rec( success:= true );
+    else
+      return rec( success:= true, result:= res.body );
+    fi;
+  end ) );
+
+Add( Download_Methods, rec(
+  name:= "via wget",
+  isAvailable:= function()
+    local exec;
+
+    exec:= Filename( DirectoriesSystemPrograms(), "wget" );
+    return exec <> fail and IsExecutableFile( exec );
+  end,
+  download:= function( url, target )
+    local res, outstream, exec, args, code;
+
+    res:= "";
+    outstream:= OutputTextString( res, true );
+    exec:= Filename( DirectoriesSystemPrograms(), "wget" );
+    if target = fail then
+      args:= [ "--quiet", "-O", "-", url ];
+    else
+      args:= [ "--quiet", "-O", target, url ];
+    fi;
+    code:= Process( DirectoryCurrent(), exec, InputTextNone(), outstream, args );
+    CloseStream( outstream );
+    if code <> 0 then
+      return rec( success:= false,
+                  error:= Concatenation( "Process returned ", String( code ) ) );
+    elif target = fail then
+      return rec( success:= true, result:= res );
+    else
+      return rec( success:= true );
+    fi;
+  end ) );
+
+Add( Download_Methods, rec(
+  name:= "via curl",
+  isAvailable:= function()
+    local exec;
+
+    exec:= Filename( DirectoriesSystemPrograms(), "curl" );
+    return exec <> fail and IsExecutableFile( exec );
+  end,
+  download:= function( url, target )
+    local res, outstream, exec, args, code;
+
+    res:= "";
+    outstream:= OutputTextString( res, true );
+    exec:= Filename( DirectoriesSystemPrograms(), "curl" );
+    if target = fail then
+      args:= [ "--silent", "-L", "--fail", "--output", "-", url ];
+    else
+      args:= [ "--silent", "-L", "--fail", "--output", target, url ];
+    fi;
+    code:= Process( DirectoryCurrent(), exec, InputTextNone(), outstream, args );
+    CloseStream( outstream );
+    if code <> 0 then
+      return rec( success:= false,
+                  error:= Concatenation( "Process returned ", String( code ) ) );
+    elif target = fail then
+      return rec( success:= true, result:= res );
+    else
+      return rec( success:= true );
+    fi;
+  end ) );
+
+
+#############################################################################
+##
+#M  Download( <url>[, <opt>] )
+##
+##  Try to download the file described by the string <url>,
+##  and return a record with the components 'success' ('true' or 'false'),
+##  and 'result' (a string, only if 'success' is 'true'),
+##  and 'error' (a string, only if 'success' is 'false').
+##
 InstallMethod( Download,
     [ "IsString" ],
     url -> Download( url, rec() ) );
@@ -29,8 +157,7 @@ InstallMethod( Download,
 InstallMethod( Download,
     [ "IsString", "IsRecord" ],
     function( url, opt )
-    local target, res, rurl, pos, domain, uri, tools, prgs, sh, tool, exec,
-          outstream, args, code, logfile;
+    local target, r, res;
 
     if IsBound( opt.target ) and IsString( opt.target ) then
       target:= opt.target;
@@ -38,68 +165,20 @@ InstallMethod( Download,
       target:= fail;
     fi;
 
-    # Try the curlInterface package.
-    if IsBoundGlobal( "DownloadURL" ) then
-      Info( InfoUtils, 2, "Download via DownloadURL (curlInterface)" );
-      res:= ValueGlobal( "DownloadURL" )( url );
-      if target <> fail then
-        FileString( target, res.result );
-        Unbind( res.result );
-      fi;
-      return res;
-    fi;
-
-    # Try the IO package.
-    if StartsWith( url, "http://" ) and IsBoundGlobal( "SingleHTTPRequest" ) then
-      Info( InfoUtils, 2, "Download via SingleHTTPRequest (IO)" );
-      rurl:= ReplacedString( url, "http://", "" );
-      pos:= Position( rurl, '/' );
-      domain:= rurl{ [ 1 .. pos-1 ] };
-      uri:= rurl{ [ pos .. Length( rurl ) ] };
-      res:= ValueGlobal( "SingleHTTPRequest" )( domain, 80, "GET", uri, rec(), false, false );
-      if res.statuscode >= 400 then
-        Info( InfoWarning, 1, "Downloading ", url, " failed: ", res.status );
-        return rec( success:= false,
-                    error:= Concatenation( "HTTP error code ", res.statuscode ) );
-      elif target <> fail then
-        FileString( target, res.body );
-        return rec( success:= true );
-      else
-        return rec( success:= true, result:= res.body );
-      fi;
-    fi;
-
-    # Try wget and curl executables.
-    tools:= [ [ "wget", ["--quiet", "-O", "-"] ],
-              [ "curl", ["--silent", "-L", "--output", "-"] ] ];
-    prgs:= DirectoriesSystemPrograms();
-    sh:= Filename( prgs, "sh" );
-    if sh <> fail and IsExecutableFile( sh ) then
-      for tool in tools do
-        exec:= Filename( prgs, tool[1] );
-        if exec <> fail and IsExecutableFile( exec ) then
-          res:= "";
-          outstream:= OutputTextString( res, true );
-
-          # Execute the command (capture both stdout and stderr).
-          args:= JoinStringsWithSeparator( tool[2], " " );
-          Append( args, " " );
-          Append( args, url );
-          Info( InfoUtils, 2, "Download via ", tool[1] );
-          code:= Process( DirectoryCurrent(), sh, InputTextNone(), outstream,
-                     [ "-c", Concatenation( exec, " ", args, " 2>&1" ) ] );
-          CloseStream( outstream );
-          if code = 0 then
-            if target <> fail then
-              FileString( target, res );
-              return rec( success:= true );
-            else
-              return rec( success:= true, result:= res );
-            fi;
-          fi;
+    # Run over the methods.
+    for r in Download_Methods do
+      if r.isAvailable() then
+        Info( InfoUtils, 2, "try Download method ", r.name );
+        res:= r.download( url, target );
+        if res.success = true then
+          return res;
         fi;
-      od;
-    fi;
+        Info( InfoUtils, 2, "Download method ", r.name, " failed with\n",
+              "#I    ", res.error );
+      else
+        Info( InfoUtils, 2, "Download method ", r.name, " is not available" );
+      fi;
+    od;
 
     return rec( success:= false, error:= "no method was applicable" );
     end );

--- a/lib/download.gi
+++ b/lib/download.gi
@@ -20,8 +20,8 @@
 ##  Note that currently the methods are *NOT* consistent in the case of
 ##  failures:
 ##
-##  - The function 'SingleHTTPRequest' does not regard the error code 301
-##    as failure.
+##  - The function 'SingleHTTPRequest' does not follow redirects as indicated
+##    by HTTP status codes 301 and 302.
 ##    This happens for example if one asks for the file at
 ##    'http://www.gap-system.org/Packages/utils.html'.
 ##

--- a/lib/download.gi
+++ b/lib/download.gi
@@ -29,7 +29,7 @@ BindGlobal( "Download_Methods", [] );
 
 Add( Download_Methods, rec(
   name:= "via DownloadURL (from the CurlInterface package)",
-  isAvailable:= {} -> IsBoundGlobal( "DownloadURL" ),
+  isAvailable:= {} -> IsPackageLoaded( "CurlInterface" ),
   download:= function( url, opt )
     local res;
 

--- a/lib/download.gi
+++ b/lib/download.gi
@@ -1,0 +1,105 @@
+##############################################################################
+##
+#W  download.gi                 GAP4 package `Utils'             Thomas Breuer
+##
+#Y  Copyright (C) 2022, The GAP Group
+
+#############################################################################
+##  
+#M  Download( <url>[, <opt>] ) 
+##  
+##  Try to download the file described by the string <url>,
+##  and return a record with the components 'success' ('true' or 'false'),
+##  and 'result' (a string, only if 'success' is 'true'),
+##  and 'error' (a string, only if 'success' is 'false').
+##
+##  Use the following tools (in this order).
+##
+##  - If the curlInterface package is available then call its
+##    'DownloadURL' function.
+##  - If the URL starts with 'http://' and if the IO package is available
+##    then call the 'SingleHTTPRequest' function from this package.
+##  - If a 'wget' executable is available then call it.
+##  - If a 'curl' executable is available then call it.
+##  
+InstallMethod( Download,
+    [ "IsString" ],
+    url -> Download( url, rec() ) );
+
+InstallMethod( Download,
+    [ "IsString", "IsRecord" ],
+    function( url, opt )
+    local target, res, rurl, pos, domain, uri, tools, prgs, sh, tool, exec,
+          outstream, args, code, logfile;
+
+    if IsBound( opt.target ) and IsString( opt.target ) then
+      target:= opt.target;
+    else
+      target:= fail;
+    fi;
+
+    # Try the curlInterface package.
+    if IsBoundGlobal( "DownloadURL" ) then
+      Info( InfoUtils, 2, "Download via DownloadURL (curlInterface)" );
+      res:= ValueGlobal( "DownloadURL" )( url );
+      if target <> fail then
+        FileString( target, res.result );
+        Unbind( res.result );
+      fi;
+      return res;
+    fi;
+
+    # Try the IO package.
+    if StartsWith( url, "http://" ) and IsBoundGlobal( "SingleHTTPRequest" ) then
+      Info( InfoUtils, 2, "Download via SingleHTTPRequest (IO)" );
+      rurl:= ReplacedString( url, "http://", "" );
+      pos:= Position( rurl, '/' );
+      domain:= rurl{ [ 1 .. pos-1 ] };
+      uri:= rurl{ [ pos .. Length( rurl ) ] };
+      res:= ValueGlobal( "SingleHTTPRequest" )( domain, 80, "GET", uri, rec(), false, false );
+      if res.statuscode >= 400 then
+        Info( InfoWarning, 1, "Downloading ", url, " failed: ", res.status );
+        return rec( success:= false,
+                    error:= Concatenation( "HTTP error code ", res.statuscode ) );
+      elif target <> fail then
+        FileString( target, res.body );
+        return rec( success:= true );
+      else
+        return rec( success:= true, result:= res.body );
+      fi;
+    fi;
+
+    # Try wget and curl executables.
+    tools:= [ [ "wget", ["--quiet", "-O", "-"] ],
+              [ "curl", ["--silent", "-L", "--output", "-"] ] ];
+    prgs:= DirectoriesSystemPrograms();
+    sh:= Filename( prgs, "sh" );
+    if sh <> fail and IsExecutableFile( sh ) then
+      for tool in tools do
+        exec:= Filename( prgs, tool[1] );
+        if exec <> fail and IsExecutableFile( exec ) then
+          res:= "";
+          outstream:= OutputTextString( res, true );
+
+          # Execute the command (capture both stdout and stderr).
+          args:= JoinStringsWithSeparator( tool[2], " " );
+          Append( args, " " );
+          Append( args, url );
+          Info( InfoUtils, 2, "Download via ", tool[1] );
+          code:= Process( DirectoryCurrent(), sh, InputTextNone(), outstream,
+                     [ "-c", Concatenation( exec, " ", args, " 2>&1" ) ] );
+          CloseStream( outstream );
+          if code = 0 then
+            if target <> fail then
+              FileString( target, res );
+              return rec( success:= true );
+            else
+              return rec( success:= true, result:= res );
+            fi;
+          fi;
+        fi;
+      od;
+    fi;
+
+    return rec( success:= false, error:= "no method was applicable" );
+    end );

--- a/lib/download.gi
+++ b/lib/download.gi
@@ -109,6 +109,11 @@ Add( Download_Methods, rec(
     code:= Process( DirectoryCurrent(), exec, InputTextNone(), outstream, args );
     CloseStream( outstream );
     if code <> 0 then
+      # wget may have created the target file; try to remove it
+      if IsBound( opt.target ) and IsString( opt.target ) and
+         IsExistingFile( opt.target ) and RemoveFile( opt.target ) <> true then
+        Error( "Download cannot remove unwanted file ", opt.target );
+      fi;
       return rec( success:= false,
                   error:= Concatenation( "Process returned ", String( code ) ) );
     elif not ( IsBound( opt.target ) and IsString( opt.target ) ) then

--- a/lib/download.gi
+++ b/lib/download.gi
@@ -41,7 +41,7 @@ Add( Download_Methods, rec(
   download:= function( url, target )
     local res;
 
-    res:= ValueGlobal( "DownloadURL" )( url );
+    res:= ValueGlobal( "DownloadURL" )( url, rec( verifyCert:= false ) );
     if target <> fail then
       FileString( target, res.result );
       Unbind( res.result );
@@ -124,9 +124,9 @@ Add( Download_Methods, rec(
     outstream:= OutputTextString( res, true );
     exec:= Filename( DirectoriesSystemPrograms(), "curl" );
     if target = fail then
-      args:= [ "--silent", "-L", "--fail", "--output", "-", url ];
+      args:= [ "--silent", "-L", "--fail", "-k", "--output", "-", url ];
     else
-      args:= [ "--silent", "-L", "--fail", "--output", target, url ];
+      args:= [ "--silent", "-L", "--fail", "-k", "--output", target, url ];
     fi;
     code:= Process( DirectoryCurrent(), exec, InputTextNone(), outstream, args );
     CloseStream( outstream );

--- a/lib/download.gi
+++ b/lib/download.gi
@@ -29,7 +29,10 @@ BindGlobal( "Download_Methods", [] );
 
 Add( Download_Methods, rec(
   name:= "via DownloadURL (from the curlInterface package)",
-  isAvailable:= {} -> IsPackageLoaded( "curlInterface" ),
+  isAvailable:= {} -> IsPackageLoaded( "curlInterface" ) and
+                      CompareVersionNumbers(
+                          InstalledPackageVersion( "curlInterface" ),
+                          "2.3.0" ),
   download:= function( url, opt )
     local res;
 
@@ -99,6 +102,9 @@ Add( Download_Methods, rec(
       args:= [ "--quiet", "-O", opt.target, url ];
     else
       args:= [ "--quiet", "-O", "-", url ];
+    fi;
+    if IsBound( opt.verifyCert ) and opt.verifyCert = false then
+      Add( args, "--no-check-certificate" );
     fi;
     code:= Process( DirectoryCurrent(), exec, InputTextNone(), outstream, args );
     CloseStream( outstream );

--- a/lib/download.gi
+++ b/lib/download.gi
@@ -74,9 +74,9 @@ Add( Download_Methods, rec(
       return rec( success:= false,
                   error:= Concatenation( "HTTP error code ", res.statuscode ) );
     elif not ( IsBound( opt.target ) and IsString( opt.target ) ) then
-      return rec( success:= true );
-    else
       return rec( success:= true, result:= res.body );
+    else
+      return rec( success:= true );
     fi;
   end ) );
 

--- a/makedoc.g
+++ b/makedoc.g
@@ -9,10 +9,17 @@ LoadPackage( "AutoDoc" );
 AutoDoc( rec( 
     scaffold := rec(
         ## MainPage := false, 
-        includes := [ "intro.xml",    "print.xml",    "lists.xml",
-                      "number.xml",   "groups.xml",   "iterator.xml",
-                      "record.xml",   "download.xml", "others.xml",
-                      "obsolete.xml", "transfer.xml" ],
+        includes := [ "intro.xml",
+                      "print.xml",
+                      "lists.xml",
+                      "number.xml",
+                      "groups.xml",
+                      "iterator.xml",
+                      "record.xml",
+                      "download.xml",
+                      "others.xml",
+                      "obsolete.xml",
+                      "transfer.xml" ],
         bib := "bib.xml", 
         entities := rec( 
             AutoDoc := "<Package>AutoDoc</Package>",

--- a/makedoc.g
+++ b/makedoc.g
@@ -9,10 +9,10 @@ LoadPackage( "AutoDoc" );
 AutoDoc( rec( 
     scaffold := rec(
         ## MainPage := false, 
-        includes := [ "intro.xml",   "print.xml",    "lists.xml", 
-                      "number.xml",  "groups.xml",   "iterator.xml", 
-                      "record.xml",  "others.xml",   "obsolete.xml", 
-                      "transfer.xml" ],
+        includes := [ "intro.xml",    "print.xml",    "lists.xml",
+                      "number.xml",   "groups.xml",   "iterator.xml",
+                      "record.xml",   "download.xml", "others.xml",
+                      "obsolete.xml", "transfer.xml" ],
         bib := "bib.xml", 
         entities := rec( 
             AutoDoc := "<Package>AutoDoc</Package>",

--- a/read.g
+++ b/read.g
@@ -19,3 +19,4 @@ ReadPackage( "utils", "lib/number.gi" );
 ReadPackage( "utils", "lib/print.gi" );
 ReadPackage( "utils", "lib/record.gi" );
 ReadPackage( "utils", "lib/string.gi" );
+ReadPackage( "utils", "lib/download.gi" );

--- a/tst/download.tst
+++ b/tst/download.tst
@@ -36,7 +36,7 @@ gap> urls:= urls{ [ 2, 3 ] };;
 gap> for pair in urls do
 >      url:= pair[1];
 >      expected:= pair[2];
->      res1:= List( meths, r -> [ r.download( url, fail ), r.position ] );;
+>      res1:= List( meths, r -> [ r.download( url, rec() ), r.position ] );;
 >      good1:= Filtered( res1, r -> r[1].success = true );;
 >      if expected = false and Length( good1 ) > 0 then
 >        Print( "success for url ", url, "?\n" );
@@ -47,7 +47,8 @@ gap> for pair in urls do
 >      fi;
 >      file:= Filename( DirectoryTemporary(), "test" );
 >      res2:= List( meths,
->               r -> [ r.download( url, Concatenation( file, r.position ) ),
+>               r -> [ r.download( url,
+>                          rec( target:= Concatenation( file, r.position ) ) ),
 >                      r.position ] );;
 >      good2:= Filtered( res2, r -> r[1].success = true );;
 >      if expected = false and Length( good2 ) > 0 then
@@ -74,6 +75,9 @@ true
 gap> IsBound( res.result ) and IsString( res.result );
 true
 gap> res:= Download( Concatenation( url, "xxx" ) );;
+
+##  The following holds only if the curlInterface package is not loaded.
+##  (This inconsistency must be fixed, but how?)
 gap> res.success;
 false
 gap> IsBound( res.error ) and IsString( res.error );

--- a/tst/download.tst
+++ b/tst/download.tst
@@ -1,4 +1,4 @@
-#@local meths, i, urls, pair, url, expected, res1, good1, n, file, res2, good2, contents, r, res;
+#@local meths, i, urls, pair, url, expected, res1, good1, n, file, res2, good2, contents, r;
 ##############################################################################
 ##
 #W  download.tst               Utils Package                     Thomas Breuer
@@ -69,15 +69,15 @@ gap> for pair in urls do
 
 ##  the example from the manual
 gap> url:= "https://www.gap-system.org/Packages/utils.html";;
-gap> res:= Download( url );;
-gap> res.success;
+gap> res1:= Download( url );;
+gap> res1.success;
 true
-gap> IsBound( res.result ) and IsString( res.result );
+gap> IsBound( res1.result ) and IsString( res1.result );
 true
-gap> res:= Download( Concatenation( url, "xxx" ) );;
-gap> res.success;
+gap> res2:= Download( Concatenation( url, "xxx" ) );;
+gap> res2.success;
 false
-gap> IsBound( res.error ) and IsString( res.error );
+gap> IsBound( res2.error ) and IsString( res2.error );
 true
 
 #############################################################################

--- a/tst/download.tst
+++ b/tst/download.tst
@@ -75,9 +75,6 @@ true
 gap> IsBound( res.result ) and IsString( res.result );
 true
 gap> res:= Download( Concatenation( url, "xxx" ) );;
-
-##  The following holds only if the curlInterface package is not loaded.
-##  (This inconsistency must be fixed, but how?)
 gap> res.success;
 false
 gap> IsBound( res.error ) and IsString( res.error );

--- a/tst/download.tst
+++ b/tst/download.tst
@@ -1,0 +1,84 @@
+#@local meths, i, urls, pair, url, expected, res1, good1, n, file, res2, good2, contents, r, res;
+##############################################################################
+##
+#W  download.tst               Utils Package                     Thomas Breuer
+##
+#Y  Copyright (C) 2022, The GAP Group
+##
+
+gap> ReadPackage( "utils", "tst/loadall.g" );;
+gap> UtilsLoadingComplete;
+true
+
+##  Test the available Download methods
+gap> meths:= List( Filtered( Download_Methods, r -> r.isAvailable() ),
+>                  ShallowCopy );;
+gap> for i in [ 1 .. Length( meths ) ] do
+>      meths[i].position:= String( i );
+>    od;
+gap> urls:= [ # a http url that gets redirected to https
+>             [ "http://www.gap-system.org/Packages/utils.html", true ],
+>             # a http url that works as such
+>             [ "http://www.math.rwth-aachen.de/index.html", true ],
+>             # a https url that exists
+>             [ "https://www.gap-system.org/Packages/utils.html", true ],
+>             # a https url that does not exist
+>             [ "https://www.gap-system.org/Packages/utilsxxx.html", false ],
+>           ];;
+
+##  The problem is that the methods do not behave consistently
+##  in the case of failure.
+##  (Well, they even do not agree what failure means.)
+##  The test results depend on which methods are available at runtime,
+##  which makes them useless as automatic tests.
+##  Thus we test only working http and https urls.
+gap> urls:= urls{ [ 2, 3 ] };;
+gap> for pair in urls do
+>      url:= pair[1];
+>      expected:= pair[2];
+>      res1:= List( meths, r -> [ r.download( url, fail ), r.position ] );;
+>      good1:= Filtered( res1, r -> r[1].success = true );;
+>      if expected = false and Length( good1 ) > 0 then
+>        Print( "success for url ", url, "?\n" );
+>      fi;
+>      n:= Length( Set( good1, r -> r[1].result ) );
+>      if n > 1 then
+>        Print( "different results (", n, ") for url ", url, "\n" );
+>      fi;
+>      file:= Filename( DirectoryTemporary(), "test" );
+>      res2:= List( meths,
+>               r -> [ r.download( url, Concatenation( file, r.position ) ),
+>                      r.position ] );;
+>      good2:= Filtered( res2, r -> r[1].success = true );;
+>      if expected = false and Length( good2 ) > 0 then
+>        Print( "success for url ", url, "?\n" );
+>      fi;
+>      if Length( good1 ) <> Length( good2 ) then
+>        Print( "different success cases for url ", url, "\n" );
+>      fi;
+>      if Length( good1 ) > 0 then
+>        contents:= good1[1][1].result;
+>        for r in good2 do
+>          if contents <> StringFile( Concatenation( file, r[2] ) ) then
+>            Print( "different files and contents for url ", url, "\n" );
+>          fi;
+>        od;
+>      fi;
+>    od;
+
+##  the example from the manual
+gap> url:= "https://www.gap-system.org/Packages/utils.html";;
+gap> res:= Download( url );;
+gap> res.success;
+true
+gap> IsBound( res.result ) and IsString( res.result );
+true
+gap> res:= Download( Concatenation( url, "xxx" ) );;
+gap> res.success;
+false
+gap> IsBound( res.error ) and IsString( res.error );
+true
+
+#############################################################################
+##
+#E

--- a/tst/others.tst
+++ b/tst/others.tst
@@ -9,7 +9,7 @@ gap> ReadPackage( "utils", "tst/loadall.g" );;
 gap> UtilsLoadingComplete;
 true
 
-## SubSection 8.1.1 
+## SubSection 9.1.1
 ## this manual example is not tested to avoid creating files triv.* 
 ## gap> LogTo( "triv.log" );
 ## gap> a := 33^5;
@@ -17,17 +17,17 @@ true
 ## gap> LogTo(); 
 ## gap> Log2HTML( "triv.log" );     
 
-## SubSection 8.2.1 
+## SubSection 9.2.1
 gap> IntOrInfinityToLaTeX( 10^3 );
 "1000"
 gap> IntOrInfinityToLaTeX( infinity );
 "\\infty"
 
-## SubSection 8.2.2 
+## SubSection 9.2.2
 gap> LaTeXStringFactorsInt( Factorial(12) );
 "2^{10} \\cdot 3^5 \\cdot 5^2 \\cdot 7 \\cdot 11"
 
-## SubSection 8.3.1 
+## SubSection 9.3.1
 gap> ConvertToMagmaInputString( Group( (1,2,3,4,5), (3,4,5) ) );
 "PermutationGroup<5|(1,2,3,4,5),\n(3,4,5)>;\n"
 gap> ConvertToMagmaInputString( Group( (1,2,3,4,5) ), "c5" );        

--- a/tst/others.tst
+++ b/tst/others.tst
@@ -1,3 +1,4 @@
+#@local M, s1, n1, n2, N, s2;
 ##############################################################################
 ##
 #W  others.tst                   Utils Package                    
@@ -31,7 +32,7 @@ gap> LaTeXStringFactorsInt( Factorial(12) );
 gap> ConvertToMagmaInputString( Group( (1,2,3,4,5), (3,4,5) ) );
 "PermutationGroup<5|(1,2,3,4,5),\n(3,4,5)>;\n"
 gap> ConvertToMagmaInputString( Group( (1,2,3,4,5) ), "c5" );        
-"c5:=PermutationGroup<5|(1,2,3,4,5)>;\n"
+"c5 := PermutationGroup<5|(1,2,3,4,5)>;\n"
 gap> ConvertToMagmaInputString( DihedralGroup( IsPcGroup, 10 ) );
 "PolycyclicGroup< f1,f2 |\nf1^2,\nf2^5,\nf2^f1 = f2^4\n>;\n"
 gap> M := GL(2,5);;  Size(M); 


### PR DESCRIPTION
The function proposed here has been more or less copied from the `PKGMAN_DownloadURL` function in [PackageManager](https://github.com/gap-packages/PackageManager).
The idea is to have *one* function in GAP that deals with web downloads.
Up to now, we have several such implementations.

- The [curlInterface](https://github.com/gap-packages/curlInterface) package provides an interface to `curl`; the function `DownloadURL` yields what is needed here, it calls the more general function `CurlRequest`.

- `SingleHTTPRequest` in [IO](https://github.com/gap-packages/io) implements `http` requests (but cannot deal with `https`).

- `GetByWgetOrCurl` in [GAPDoc](https://github.com/frankluebeck/GAPDoc) calls `wget` if this is available and `curl` otherwise in order to download a file and return its contents.

- `FetchMoreFactors` in [StandardFF](https://github.com/frankluebeck/StandardFF) calls `wget` in order to download and unzip a file and use its contents in the GAP session (optionally it writes the contents to a prescribed local file).

- `FetchBrentFactors` in [FactInt](https://github.com/gap-packages/FactInt) calls `curl` for the same purpose.

- `PKGMAN_DownloadURL` in [PackageManager](https://github.com/gap-packages/PackageManager) calls `DownloadURL` or `wget` or `curl` (in this order) if they are available.

- Julia's [GAP.jl](https://github.com/oscar-system/GAP.jl) package replaces GAP's `PKGMAN_DownloadURL` by a Julia function. As soon as one standard function for web downloads is used throughout on the GAP side, a replacement of that function by a Julia function will work for all web download triggered from GAP.

Various packages use the above functions, for example `DownloadFile` in [reclasses](https://github.com/gap-packages/resclasses) calls IO's `SingleHTTPRequest`, and the [AtlasRep](http://www.math.rwth-aachen.de/~Thomas.Breuer/atlasrep/index.html) package uses `SingleHTTPRequest` or `wget` for downloading files and perhaps creating local copies --this code will have to be changed/simplified as soon as there is a "standard" way to perform these tasks.

Some open questions:

- Which URL strings do we want to allow?
  The protocols `http` and `https` are supported. What about `ftp`? Others?

- The different tools have different opinions about `success`:
  When a requested file is not found then `curl` returns a string that contains an error message and exits with code `0`, whereas `wget` exits with an error code.
  How shall we deal with this?
  (@fingolfin mentioned that one can use an optional argument of `curl`; this is, however, not available in curlInterface's `DownloadURL`.)

- Which other features shall be supported, such as unzipping downloaded files?

- What shall happen if one wants to write a local file (component `target` in the optional record) but one is not allowed to write the given file?

(Once we agree on what we expect from the function in question, it will be a challenge to write suitable tests for the various situations, depending on which executables are available.)