### PR TITLE
Add OptionRecordWithDefaults

### DIFF
--- a/doc/record.xml
+++ b/doc/record.xml
@@ -36,6 +36,45 @@ gap> [a,b,c];
 ]]>
 </Example>
 
+<ManSection>
+   <Func Name="OptionRecordWithDefaults"
+         Arg="defaults, useroptions" />
+<Description>
+
+This function simplifies handling records which are intended
+to be used for expressing configuration options. <A>defaults</A>
+represents the a "default record", and <A>useroptions</A> lets
+the user give new values for values in <A>defaults</A>.
+<P/>
+The function returns a record with the same component names
+as <A>defaults</A> which has the same values as <A>defaults</A>,
+except for those component names in <A>useroptions</A>, where
+the values in <A>useroptions</A> are used instead.
+
+An error is given if <A>useroptions</A> contains any
+component names not in <A>defaults</A>.
+
+This function is designed to support functions with
+optional arguments given as a variadic argument, like
+<C>function(x,y,options...)</C>. To support this,
+if <A>useroptions</A> is an empty list it is treated as
+an empty record, and if <A>useroptions</A> is a list of length
+1 containing a record, this record is used as <A>useroptions</A>.
+<P/>
+</Description>
+</ManSection>
+<Example>
+<![CDATA[
+gap> defaults := rec(a := 1, b := 2);;
+gap> OptionRecordWithDefaults(defaults, rec(a := 7));
+rec( a := 7, b := 2 )
+gap> OptionRecordWithDefaults(defaults, rec(b := 7));
+rec( a := 1, b := 7 )
+gap> OptionRecordWithDefaults(defaults, rec(c := 7));
+Error, Unknown option: c
+]]>
+</Example>
+
 </Section>
 
 </Chapter>

--- a/lib/record.gd
+++ b/lib/record.gd
@@ -15,6 +15,9 @@
 ##
 DeclareGlobalFunction( "AssignGlobals" );
 
+
+DeclareGlobalFunction( "OptionRecordWithDefaults" );
+
 #############################################################################
 ##
 #E  record.gd  . . . . . . . . . . . . . . . . . . . . . . . . . . . ends here

--- a/lib/record.gi
+++ b/lib/record.gi
@@ -40,6 +40,39 @@ InstallGlobalFunction( AssignGlobals,
           Set(names),"\n");
   end );
 
+
+InstallGlobalFunction( OptionRecordWithDefaults,
+  function(default, useroptions)
+    local name, ret;
+    ret := rec();
+
+    if IsList(useroptions) then
+      if IsEmpty(useroptions) then
+        return default;
+      elif Length(useroptions) = 1 then
+        useroptions := useroptions[1];
+      else
+        ErrorNoReturn("Too many arguments for function");
+      fi;
+    fi;
+
+    if not IsRecord(useroptions) then
+      ErrorNoReturn("Options should be a record");
+    fi;
+
+    ret := ShallowCopy(default);
+
+    for name in RecNames(useroptions) do
+      if not IsBound(default.(name)) then
+        ErrorNoReturn(Concatenation("Unknown option: " , name));
+      else
+        ret.(name) := useroptions.(name);
+      fi;
+    od;
+
+    return ret;
+  end);
+
 #############################################################################
 ##
 #E  record.gi  . . . . . . . . . . . . . . . . . . . . . . . . . . . ends here

--- a/tst/optionrecordwithdefaults.tst
+++ b/tst/optionrecordwithdefaults.tst
@@ -1,0 +1,31 @@
+#@local defaults
+
+##############################################################################
+##
+#W  record.tst                  Utils Package                    
+##
+#Y  Copyright (C) 2015-2019, The GAP Group 
+##  
+
+gap> ReadPackage( "utils", "tst/loadall.g" );;
+gap> UtilsLoadingComplete;
+true
+
+#
+gap> defaults := rec(a := 1, b := 2);;
+gap> OptionRecordWithDefaults(defaults, rec(a := 7));
+rec( a := 7, b := 2 )
+gap> OptionRecordWithDefaults(defaults, rec(b := 7));
+rec( a := 1, b := 7 )
+gap> OptionRecordWithDefaults(defaults, []);
+rec( a := 1, b := 2 )
+gap> OptionRecordWithDefaults(defaults, [rec(b := 7)]);
+rec( a := 1, b := 7 )
+gap> OptionRecordWithDefaults(defaults, rec(c := 7));
+Error, Unknown option: c
+gap> OptionRecordWithDefaults(defaults, [rec(b := 7), rec(a := 1)]);
+Error, Too many arguments for function
+gap> OptionRecordWithDefaults(defaults, 2);
+Error, Options should be a record
+gap> OptionRecordWithDefaults(defaults, [2]);
+Error, Options should be a record


### PR DESCRIPTION
This adds a function I use in several of my packages.

The idea behind the function is one often wants to add optional configuration options to a function, you write something like:

```
myfunc := function(x,y, options...)
local r;
r := OptionRecordWithDefaults(rec(size := 2, fast := true)), options);
...
```

And users can optionally pass a 3rd argument which says `rec(fast := false)` to override the "defaults".

To avoid spelling mistakes, `options` can only contain names which are given in the default.

This serves a similar purpose to the "options stack", but avoids making global changes. 

I am very happy to change the function name, or documentation (I'm not a great fan of either).