### PR TITLE
Remove pcp code from PcGroupToMagmaFormat

### DIFF
--- a/lib/magma.gi
+++ b/lib/magma.gi
@@ -73,17 +73,10 @@ end );
 InstallMethod( PcGroupToMagmaFormat, "pc-group", true, [IsPcGroup], 0, 
     function(G)
     local str, g, n, r, gens, rels, i, j;
-    if IsPcpGroup(G) then
-        g := Pcp(G);
-        r := RelativeOrders(Collector(G));
-        n := Length(r);
-        gens := List(g,String);
-    else
-        g := Pcgs(G);
-        n := Length(g);
-        r := RelativeOrders(g);
-        gens := List(g,String);
-    fi;
+    g := Pcgs(G);
+    n := Length(g);
+    r := RelativeOrders(g);
+    gens := List(g,String);
     str := "PolycyclicGroup< ";
     Append(str, JoinStringsWithSeparator(gens));
     Append(str, " |\n");


### PR DESCRIPTION
It was never usable anyway, as the function was only installed for an argument in the filter `IsPcGroup`, which is disjoint from `IsPcpGroup`. So this was dead code.