### PR TITLE
fix `PrimitiveElement` vs. `PrimitiveRoot`

### DIFF
--- a/lib/magma.gi
+++ b/lib/magma.gi
@@ -123,10 +123,13 @@ InstallMethod( MatrixGroupToMagmaFormat, "matrix group over a finite field",
 
     mats := GeneratorsOfGroup( G );
     F := Field( Flat( mats ) );
+    if not IsFinite( F ) then
+      TryNextMethod();
+    fi;
     p := Characteristic( F ); 
     e := DegreeOverPrimeField( F ); 
     q := Size( F );
-    w := PrimitiveElement( F ); 
+    w := PrimitiveRoot( F );
     zero := Zero( F ); 
     one := One( F );
     matrix := mats[1];


### PR DESCRIPTION
In GAP, `PrimitiveElement(F)` denotes an element that generates `F` over `LeftActingDomain(F)`, whereas `PrimitiveRoot(F)` is a generator of the multiplicative group of `F` if `F` is a finite field.
In Magma, according to its documentation, `PrimitiveElement(F)` for a finite field `F` is always a primitive root.

(Currently the way how finite fields are constructed in GAP seems to guarantee that `PrimitiveElement(F)` always is a primitive root, like in Magma. Thus there was no problem in practice.)