### PR TITLE
support timeout in `Download`

### DIFF
--- a/doc/download.xml
+++ b/doc/download.xml
@@ -51,6 +51,17 @@ An optional record <A>opt</A> can be given.
 The following components are supported.
 <P/>
 <List>
+<Mark><C>maxTime</C></Mark>
+<Item>
+  If this component is bound then its value must be a nonnegative integer
+  <M>n</M>, meaning that the function gives up after <M>n</M> seconds.
+  <P/>
+  A zero value of <M>n</M> means that no timeout is set, the method will
+  never give up in this case.
+  <P/>
+  The default for <M>n</M> is given by the value of the user preference
+  <C>DownloadMaxTime</C> (see <Ref Subsect="subsec-DownloadMaxTime"/>).
+</Item>
 <Mark><C>target</C></Mark>
 <Item>
   If this component is bound then its value must be a string
@@ -63,7 +74,7 @@ The following components are supported.
   If this component is bound and has the value <K>false</K>
   then those download methods that are based on <C>curl</C> or <C>wget</C>
   will omit the check of the server's certificate.
-
+  <P/>
   The same effect is achieved for all <Ref Func="Download"/> calls
   by setting the user preference <C>DownloadVerifyCertificate</C>
   (see <Ref Subsect="subsec-DownloadVerifyCertificate"/>) to <K>false</K>
@@ -113,6 +124,24 @@ Sometimes it can be necessary to change it, e.g. to work around issues
 with old operating systems which may not be able to correctly verify new
 certificates. In general it is better to update such a system, but if that is
 not an option, then disabling certificate checks may be a good last resort.
+
+</Subsection>
+
+<Subsection Label="subsec-DownloadMaxTime">
+<Heading>User preference <C>DownloadMaxTime</C></Heading>
+<Index Key="DownloadMaxTime"><C>DownloadMaxTime</C></Index>
+
+The value <C>0</C> (the default) means that no timeout is set
+in calls of <Ref Func="Download"/>.
+If the value is a positive integer <M>n</M> then those download methods that
+support a timeout will give up after <M>n</M> seconds.
+<P/>
+One can set the value of the preference to be <C>val</C> via
+<Ref Func="SetUserPreference" BookName="ref"/>, by calling
+<C>SetUserPreference( "utils", "DownloadMaxTime", val )</C>,
+and access the current value via
+<Ref Func="UserPreference" BookName="ref"/>, by calling
+<C>UserPreference( "utils", "DownloadMaxTime" )</C>.
 
 </Subsection>
 

--- a/lib/download.gd
+++ b/lib/download.gd
@@ -34,3 +34,21 @@ curl or wget will omit the check of the server's certificate."
   package:= "utils",
   ) );
 
+
+#############################################################################
+##
+#U  DownloadMaxTime
+##
+DeclareUserPreference( rec(
+  name:= "DownloadMaxTime",
+  description:= [
+    "The value '0' (the default) means that no timeout is set \
+in calls of 'Download'. \
+If the value is a positive integer 'n' then those download methods that \
+support a timeout will give up after 'n' seconds."
+    ],
+  default:= 0,
+  check:= val -> val = 0 or IsPosInt( val ),
+  package:= "utils",
+  ) );
+

--- a/lib/download.gi
+++ b/lib/download.gi
@@ -99,6 +99,12 @@ Add( Download_Methods, rec(
   download:= function( url, opt )
     local res, outstream, exec, args, code;
 
+    if IsBound( opt.maxTime ) and opt.maxTime <> 0 then
+      # wget 1.20.3 ignores a given timeout.
+      # (wget 1.21.3 would support timeout.)
+      return rec( success:= false, error:= "no support for given timeout" );
+    fi;
+
     res:= "";
     outstream:= OutputTextString( res, true );
     exec:= Filename( DirectoriesSystemPrograms(), "wget" );

--- a/tst/download.tst
+++ b/tst/download.tst
@@ -75,10 +75,13 @@ gap> for pair in urls do
 >      if expected = false and Length( good3 ) > 0 then
 >        Print( "success for url ", url, "?\n" );
 >      fi;
->      # The IO based method cannot handle the 'maxTime' parameter.
 >      io:= First( meths,
 >                  x -> StartsWith( x.name, "via SingleHTTPRequest" ) );
->      good1:= Filtered( good1, x -> x[2] <> io.position );
+>      if io <> fail then
+>        # The IO based method is available.
+>        # It cannot handle the 'maxTime' parameter.
+>        good1:= Filtered( good1, x -> x[2] <> io.position );
+>      fi;
 >      if List( good1, x -> x[2] ) <> List( good3, x -> x[2] ) then
 >        Print( "different success cases for url ", url, ":\n",
 >               List( good1, x -> x[2] ), " vs. ", List( good3, x -> x[2] ),

--- a/tst/download.tst
+++ b/tst/download.tst
@@ -1,4 +1,4 @@
-#@local meths, i, urls, pair, url, expected, res1, good1, n, file, res2, good2, contents, r;
+#@local meths, i, urls, pair, url, expected, res1, good1, n, file, res2, good2, contents, r, res3, good3, io;
 ############################################################################
 ##
 #W  download.tst               Utils Package                   Thomas Breuer
@@ -54,8 +54,10 @@ gap> for pair in urls do
 >      if expected = false and Length( good2 ) > 0 then
 >        Print( "success for url ", url, "?\n" );
 >      fi;
->      if Length( good1 ) <> Length( good2 ) then
->        Print( "different success cases for url ", url, "\n" );
+>      if List( good1, x -> x[2] ) <> List( good2, x -> x[2] ) then
+>        Print( "different success cases for url ", url, ":\n",
+>               List( good1, x -> x[2] ), " vs. ", List( good2, x -> x[2] ),
+>               "\n" );
 >      fi;
 >      if Length( good1 ) > 0 then
 >        contents:= good1[1][1].result;
@@ -64,6 +66,23 @@ gap> for pair in urls do
 >            Print( "different files and contents for url ", url, "\n" );
 >          fi;
 >        od;
+>      fi;
+>      res3:= List( meths,
+>               r -> [ r.download( url,
+>                        rec( maxTime:= 10 ) ),
+>                      r.position ] );;
+>      good3:= Filtered( res3, r -> r[1].success = true );;
+>      if expected = false and Length( good3 ) > 0 then
+>        Print( "success for url ", url, "?\n" );
+>      fi;
+>      # The IO based method cannot handle the 'maxTime' parameter.
+>      io:= First( meths,
+>                  x -> StartsWith( x.name, "via SingleHTTPRequest" ) );
+>      good1:= Filtered( good1, x -> x[2] <> io.position );
+>      if List( good1, x -> x[2] ) <> List( good3, x -> x[2] ) then
+>        Print( "different success cases for url ", url, ":\n",
+>               List( good1, x -> x[2] ), " vs. ", List( good3, x -> x[2] ),
+>               "\n" );
 >      fi;
 >    od;
 

--- a/tst/download.tst
+++ b/tst/download.tst
@@ -1,4 +1,4 @@
-#@local meths, i, urls, pair, url, expected, res1, good1, n, file, res2, good2, contents, r, res3, good3, io;
+#@local meths, i, urls, pair, url, expected, res1, good1, n, file, res2, good2, contents, r, res3, good3, bad
 ############################################################################
 ##
 #W  download.tst               Utils Package                   Thomas Breuer
@@ -75,19 +75,27 @@ gap> for pair in urls do
 >      if expected = false and Length( good3 ) > 0 then
 >        Print( "success for url ", url, "?\n" );
 >      fi;
->      io:= First( meths,
->                  x -> StartsWith( x.name, "via SingleHTTPRequest" ) );
->      if io <> fail then
->        # The IO based method is available.
->        # It cannot handle the 'maxTime' parameter.
->        good1:= Filtered( good1, x -> x[2] <> io.position );
->      fi;
+>      # The IO and wget based methods are available.
+>      # They cannot handle the 'maxTime' parameter.
+>      bad:= Filtered( meths,
+>                  x -> StartsWith( x.name, "via SingleHTTPRequest" ) or
+>                       StartsWith( x.name, "via wget" ) );
+>      bad:= List( bad, x -> x.position );
+>      good1:= Filtered( good1, x -> not x[2] in bad );
 >      if List( good1, x -> x[2] ) <> List( good3, x -> x[2] ) then
 >        Print( "different success cases for url ", url, ":\n",
 >               List( good1, x -> x[2] ), " vs. ", List( good3, x -> x[2] ),
 >               "\n" );
 >      fi;
 >    od;
+
+##  test timeout
+gap> res1:= Download( "https://httpbun.com/delay/3", rec( maxTime:= 1 ) );;
+gap> res1.success = false;
+true
+gap> res1:= Download( "https://httpbun.com/delay/3", rec( maxTime:= 5 ) );;
+gap> res1.success = true;
+true
 
 ##  the example 9.1.1 from the manual
 gap> url:= "https://www.gap-system.org/index.html";;


### PR DESCRIPTION
The idea is to specify the maximum number of seconds to wait for a download, via the optional component `maxTime` in the optional second argument of `Download`.
The default value is given by the new user preference `DownloadMaxTime` of the utils package, and the default for that is zero, meaning that there is no timeout.

The methods stored in `Download_Methods` either use a given nonzero `maxTime` value or signal failure (the latter holds for the method from the IO package, which does not support timeouts).

~~(Up to now, I have not managed to test in which situations this timeout really helps. This is why this pull request is marked as draft.)~~