### PR TITLE
doc: fix CDATA sections

### DIFF
--- a/doc/download.xml
+++ b/doc/download.xml
@@ -82,8 +82,7 @@ The following components are supported.
 </Item>
 </List>
 <P/>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> url:= "https://www.gap-system.org/index.html";;
 gap> res1:= Download( url );;
 gap> res1.success;
@@ -95,8 +94,7 @@ gap> res2.success;
 false
 gap> IsBound( res2.error ) and IsString( res2.error );
 true
-]]>
-</Example>
+]]></Example>
 </Description>
 </ManSection>
 

--- a/doc/groups.xml
+++ b/doc/groups.xml
@@ -27,16 +27,14 @@ It provides a method for <C>Comm</C> when the argument is a list
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> Comm( [ (1,2), (2,3) ] );
 (1,2,3)
 gap> Comm( [(1,2),(2,3),(3,4),(4,5),(5,6)] );
 (1,5,6)
 gap> Comm(Comm(Comm(Comm((1,2),(2,3)),(3,4)),(4,5)),(5,6));  ## the same
 (1,5,6)
-]]>
-</Example>
+]]></Example>
 
 <ManSection>
    <Oper Name="IsCommuting"
@@ -48,16 +46,14 @@ It tests whether two elements in a group commute.
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> D12 := DihedralGroup( 12 );
 <pc group of size 12 with 3 generators>
 gap> SetName( D12, "D12" ); 
 gap> a := D12.1;;  b := D12.2;;  
 gap> IsCommuting( a, b );
 false
-]]>
-</Example>
+]]></Example>
 
 <ManSection>
    <Oper Name="ListOfPowers"
@@ -70,8 +66,7 @@ The operation <C>ListOfPowers(g,exp)</C> returns the list
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> ListOfPowers( 2, 20 );
 [ 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384,
  32768, 65536, 131072, 262144, 524288, 1048576 ]
@@ -80,8 +75,7 @@ gap> ListOfPowers( (1,2,3)(4,5), 12 );
  (1,2,3)(4,5), (1,3,2), (4,5), (1,2,3), (1,3,2)(4,5), () ]
 gap> ListOfPowers( D12.2, 6 );
 [ f2, f3, f2*f3, f3^2, f2*f3^2, <identity> of ... ]
-]]>
-</Example>
+]]></Example>
 
 <ManSection>
    <Oper Name="GeneratorsAndInverses"
@@ -94,14 +88,12 @@ followed by the inverses of these generators.
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> GeneratorsAndInverses( D12 );
 [ f1, f2, f3, f1, f2*f3^2, f3^2 ]
 gap> GeneratorsAndInverses( SymmetricGroup(5) );     
 [ (1,2,3,4,5), (1,2), (1,5,4,3,2), (1,2) ]
-]]>
-</Example>
+]]></Example>
 
 
 <ManSection>
@@ -121,8 +113,7 @@ group are described here:
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> UpperFittingSeries( D12 );  LowerFittingSeries( D12 );
 [ Group([  ]), Group([ f3, f2*f3 ]), Group([ f1, f3, f2*f3 ]) ]
 [ D12, Group([ f3 ]), Group([  ]) ]
@@ -141,8 +132,7 @@ gap> List( last, StructureDescription );
 [ "S4", "A4", "C2 x C2", "1" ]
 gap> FittingLength( S4);
 3
-]]>
-</Example>
+]]></Example>
 
 </Section>
 
@@ -177,8 +167,7 @@ and, if necessary, converting back again to left cosets.
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> a4 := Group( (1,2,3), (2,3,4) );; SetName( a4, "a4" );
 gap> k4 := Group( (1,2)(3,4), (1,3)(2,4) );; SetName( k4, "k4" );
 gap> rc := RightCosets( a4, k4 );
@@ -199,8 +188,7 @@ gap> (1,2,3)*lc[2] = lc[3];
 true
 gap> lc[2]^(1,3,2) = lc[3];
 true
-]]>
-</Example>
+]]></Example>
 
 <Subsection Label="subsec-inverse">
 <Heading>Inverse</Heading> 
@@ -209,14 +197,12 @@ and conversely.
 This is an abuse of the attribute <C>Inverse</C>, since the standard 
 requirement, that <M>x*x^{-1}</M> is an identity, does not hold. 
 <P/>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> Inverse( rc[3] ) = lc[3];
 true
 gap> Inverse( lc[2] ) = rc[2];
 true
-]]>
-</Example> 
+]]></Example> 
 </Subsection>
 
 </Section> 
@@ -239,8 +225,7 @@ Note that anything may happen if the resulting map is not a homomorphism!
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> G := Group( (1,2,3), (3,4,5), (5,6,7), (7,8,9) );;
 gap> phi := EpimorphismByGenerators( FreeGroup("a","b","c","d"), G );
 [ a, b, c, d ] -> [ (1,2,3), (3,4,5), (5,6,7), (7,8,9) ]
@@ -259,8 +244,7 @@ gap> Image( epi, (1,2,3) );
 ()
 gap> Image( epi, (1,3,2) );
 (8,9)
-]]>
-</Example>
+]]></Example>
 
 
 <ManSection>
@@ -294,8 +278,7 @@ see <Ref Oper="Embedding" BookName="ref"/>.
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> s4 := Group( (1,2),(2,3),(3,4) );;
 gap> s3 := Group( (5,6),(6,7) );;
 gap> c3 := Subgroup( s3, [ (5,6,7) ] );;
@@ -320,8 +303,7 @@ gap> a := ImageElm( Embedding( dp, 1 ), (1,4,3) );;
 gap> b := ImageElm( Embedding( dp, 2 ), (5,7,6) );; 
 gap> a*b in Pfi;
 true
-]]>
-</Example>
+]]></Example>
 
 
 <ManSection>
@@ -420,8 +402,7 @@ The first of these is the zero map, the second is the identity.
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> gens := [ (1,2,3,4), (1,2)(3,4) ];; 
 gap> d8 := Group( gens );;
 gap> SetName( d8, "d8" );
@@ -448,20 +429,17 @@ gap> IdempotentEndomorphisms( d8 );
   [ (1,2,3,4), (1,2)(3,4) ] -> [ (), (1,4)(2,3) ], 
   [ (1,2,3,4), (1,2)(3,4) ] -> [ (1,4)(2,3), (1,4)(2,3) ], 
   [ (1,2,3,4), (1,2)(3,4) ] -> [ (1,2,3,4), (1,2)(3,4) ] ]
-]]>
-</Example>
+]]></Example>
 
 The quaternion group <C>q8</C> is an example of a group with a tail: 
 there is only one subgroup in the lattice which covers the identity subgroup. 
 The only idempotent isomorphisms of such groups are the identity mapping 
 and the zero mapping because the only pairs <M>N,R</M> are the whole group and the identity subgroup. 
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> q8 := QuaternionGroup( 8 );;
 gap> IdempotentEndomorphisms( q8 );
 [ [ x, y ] -> [ <identity> of ..., <identity> of ... ], [ x, y ] -> [ x, y ] ]
-]]>
-</Example>
+]]></Example>
 
 <ManSection>
    <Oper Name="DirectProductOfFunctions"
@@ -473,8 +451,7 @@ this operation return the product homomorphism
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> c4 := Group( (1,2,3,4) );; 
 gap> c2 := Group( (5,6) );; 
 gap> f1 := GroupHomomorphismByImages( c4, c2, [(1,2,3,4)], [(5,6)] );;
@@ -489,8 +466,7 @@ gap> f := DirectProductOfFunctions( c4c3, c2c6, f1, f2 );
 [ (1,2,3,4), (5,6,7) ] -> [ (1,2), (3,5,7)(4,6,8) ]
 gap> ImageElm( f, (1,4,3,2)(5,7,6) ); 
 (1,2)(3,7,5)(4,8,6)
-]]>
-</Example>
+]]></Example>
 
 <ManSection>
    <Oper Name="DirectProductOfAutomorphismGroups"
@@ -502,8 +478,7 @@ of automorphisms of <M>G_1 \times G_2</M>.
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> c9 := Group( (1,2,3,4,5,6,7,8,9) );; 
 gap> ac9 := AutomorphismGroup( c9 );; 
 gap> q8 := QuaternionGroup( IsPermGroup, 8 );;
@@ -520,8 +495,7 @@ gap> a := genA[1]*genA[5];
   (10,11,12,13)(14,15,16,17) ]
 gap> ImageElm( a, (1,9,8,7,6,5,4,3,2)(10,14,12,16)(11,17,13,15) );
 (1,8,6,4,2,9,7,5,3)(10,16,12,14)(11,15,13,17)
-]]>
-</Example>
+]]></Example>
 
 </Section> 
 

--- a/doc/intro.xml
+++ b/doc/intro.xml
@@ -20,11 +20,9 @@ This package was first distributed as part of the &GAP; 4.8.2 distribution.
 <P/> 
 
 The package is loaded with the command
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> LoadPackage( "utils" ); 
-]]>
-</Example>
+]]></Example>
 <P/>
 Functions have been transferred from the following packages: 
 <List>
@@ -75,24 +73,20 @@ can be found in the documentation folder.
 The <Code>html</Code> versions, with or without &MathJax;, 
 may be rebuilt as follows: 
 <P/>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> ReadPackage( "utils", "makedoc.g" ); 
-]]>
-</Example>
+]]></Example>
 <P/>
 It is possible to check that the package has been installed correctly
 by running the test files (which terminates the &GAP; session): 
 <P/>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> ReadPackage( "utils", "tst/testall.g" );
 Architecture: . . . . . 
 testing: . . . . . 
 . . . 
 #I  No errors detected while testing
-]]>
-</Example>
+]]></Example>
 <P/>
 
 Note that functions listed in this manual that are currently 

--- a/doc/iterator.xml
+++ b/doc/iterator.xml
@@ -42,8 +42,7 @@ The operation <C>AllIsomorphisms</C> produces the list or isomorphisms.
 <P/> 
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> G := SmallGroup( 6,1);; 
 gap> iter := AllIsomorphismsIterator( G, s3 );;
 gap> NextIterator( iter );
@@ -57,8 +56,7 @@ gap> AllIsomorphisms( G, s3 );
 gap> iter := AllIsomorphismsIterator( G, s3 );;
 gap> for h in iter do Print( ImageElm( h, G.1 ) = (6,7), ", " ); od;
 true, false, false, true, false, false,
-]]>
-</Example>
+]]></Example>
 
 <ManSection>
    <Oper Name="AllSubgroupsIterator"
@@ -74,8 +72,7 @@ over the entries in these classes.
 <P/> 
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> c3c3 := Group( (1,2,3), (4,5,6) );; 
 gap> iter := AllSubgroupsIterator( c3c3 );
 <iterator>
@@ -86,8 +83,7 @@ Group( [ (1,2,3) ] )
 Group( [ (1,2,3)(4,5,6) ] )
 Group( [ (1,3,2)(4,5,6) ] )
 Group( [ (4,5,6), (1,2,3) ] )
-]]>
-</Example>
+]]></Example>
 
 </Section> 
 
@@ -109,8 +105,7 @@ of a first iterator and <M>y</M> is the output of a second iterator.
 <P/> 
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> it1 := Iterator( [ 1, 2, 3 ] );;
 gap> it2 := Iterator( [ 4, 5, 6 ] );;
 gap> iter := CartesianIterator( it1, it2 );;
@@ -124,8 +119,7 @@ gap> while not IsDoneIterator(iter) do Print(NextIterator(iter),"\n"); od;
 [ 3, 4 ]
 [ 3, 5 ]
 [ 3, 6 ]
-]]>
-</Example>
+]]></Example>
 
 <ManSection>
    <Oper Name="UnorderedPairsIterator"
@@ -140,8 +134,7 @@ In the case <M>L = [1,2,3,\ldots]</M> the pairs are ordered as
 <P/> 
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> L := [6,7,8,9];;
 gap> iterL := IteratorList( L );; 
 gap> pairsL := UnorderedPairsIterator( iterL );;                              
@@ -164,8 +157,7 @@ gap> NextIterator( pairs4 );
 [ 4, 4 ]
 gap> IsDoneIterator( pairs4 );
 true
-]]>
-</Example>
+]]></Example>
 
 </Section> 
 

--- a/doc/lists.xml
+++ b/doc/lists.xml
@@ -29,8 +29,7 @@ the list of length <M>n-1</M> containing all the differences
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> List( [1..12], n->n^3 );
 [ 1, 8, 27, 64, 125, 216, 343, 512, 729, 1000, 1331, 1728 ]
 gap> DifferencesList( last );
@@ -39,8 +38,7 @@ gap> DifferencesList( last );
 [ 12, 18, 24, 30, 36, 42, 48, 54, 60, 66 ]
 gap> DifferencesList( last );
 [ 6, 6, 6, 6, 6, 6, 6, 6, 6 ]
-]]>
-</Example>
+]]></Example>
 
 
 <ManSection>
@@ -57,8 +55,7 @@ An error is returned if an entry is zero.
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> List( [0..10], n -> Factorial(n) );
 [ 1, 1, 2, 6, 24, 120, 720, 5040, 40320, 362880, 3628800 ]
 gap> QuotientsList( last );
@@ -74,8 +71,7 @@ gap> FloatQuotientsList( [1..10] );
 [ 2., 1.5, 1.33333, 1.25, 1.2, 1.16667, 1.14286, 1.125, 1.11111 ]
 gap> Product( last );
 10. 
-]]>
-</Example>
+]]></Example>
 
 
 <ManSection>
@@ -93,8 +89,7 @@ in order to be recognized as a cycle.
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> L := [1..20];;  L[1]:=13;;                                              
 gap> for i in [1..19] do                                                     
 >        if IsOddInt(L[i]) then L[i+1]:=3*L[i]+1; else L[i+1]:=L[i]/2; fi;
@@ -120,8 +115,7 @@ gap> P := Positions( L, 157 );
 gap> Length( C );  DifferencesList( P );
 12
 [ 12, 12, 12, 12, 12, 12, 12 ]
-]]>
-</Example>
+]]></Example>
 
 <ManSection>
    <Oper Name="RandomCombination"
@@ -134,13 +128,11 @@ of a set <M>S</M>.
 <P/>
 </Description>
 </ManSection>
-<Log>
-<![CDATA[
+<Log><![CDATA[
 gap> ## "6 aus 49" is a common lottery in Germany
 gap> RandomCombination( [1..49], 6 ); 
 [ 2, 16, 24, 26, 37, 47 ]
-]]>
-</Log>
+]]></Log>
 
 </Section>
 
@@ -181,8 +173,7 @@ although a greedy algorithm is usually quicker.
 </Description>
 </ManSection>
 <P/>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> J := [ [1,2,3], [3,4], [3,4], [1,2,4] ];;
 gap> DistinctRepresentatives( J );
 [ 1, 3, 4, 2 ]
@@ -202,8 +193,7 @@ gap> trans := CommonTransversal( d16, c4 );
 [ (), (2,8)(3,7)(4,6), (1,2,3,4,5,6,7,8), (1,2)(3,8)(4,7)(5,6) ]
 gap> IsCommonTransversal( d16, c4, trans );
 true
-]]>
-</Example>
+]]></Example>
 
 </Section>
 
@@ -225,16 +215,14 @@ is a composite of the functions <C>String( obj )</C> and
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> gens := GeneratorsOfGroup( DihedralGroup(12) );
 [ f1, f2, f3 ]
 gap> String( gens );                                
 "[ f1, f2, f3 ]"
 gap> BlankFreeString( gens );                       
 "[f1,f2,f3]"
-]]>
-</Example>
+]]></Example>
 
 </Section>
 

--- a/doc/matrix.xml
+++ b/doc/matrix.xml
@@ -40,8 +40,7 @@ while <M>M_8 = M_4 \oplus M_4</M> has <M>16</M> decompositions (not listed).
 <P/> 
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> M6 := [ [1,2,0,0,0,0], [3,4,0,0,0,0], [5,6,0,0,0,0],                       
 >            [0,0,9,0,0,0], [0,0,0,1,2,3], [0,0,0,4,5,6] ];;
 gap> Display( M6 );
@@ -86,8 +85,7 @@ gap> Display( M8 );
 gap> L8 := DirectSumDecompositionMatrices( M8 );;
 gap> Length( L8 ); 
 16
-]]>
-</Example>
+]]></Example>
 <P/>
 
 The current method does not, however, catch all possible decompositions. 
@@ -98,8 +96,7 @@ There are clearly two <M>2</M>-factor decompositions with a
 <M>2</M>-by-<M>3</M> and a <M>3</M>-by-<M>2</M> factor, 
 but these are not found at present.
 <P/>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> M5 := [ [1,2,0,0,0], [3,4,0,0,0], [0,0,0,0,0],
 >            [0,0,0,6,7], [0,0,0,8,9] ];;
 gap> Display(M5);
@@ -110,8 +107,7 @@ gap> Display(M5);
   [  0,  0,  0,  8,  9 ] ]
 gap> L5 := DirectSumDecompositionMatrices( M5 ); 
 [ [ [ [ 1, 2 ], [ 3, 4 ] ], [ [ 0 ] ], [ [ 6, 7 ], [ 8, 9 ] ] ] ]
-]]>
-</Example>
+]]></Example>
 
 </Section> 
 

--- a/doc/number.xml
+++ b/doc/number.xml
@@ -37,8 +37,7 @@ whose prime factors lie in <M>L</M>.
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> AllSmoothIntegers( 3, 1000 );
 [ 1, 2, 3, 4, 6, 8, 9, 12, 16, 18, 24, 27, 32, 36, 48, 54, 64, 72, 81, 96, 
   108, 128, 144, 162, 192, 216, 243, 256, 288, 324, 384, 432, 486, 512, 576, 
@@ -50,8 +49,7 @@ gap> Length( last );
 gap> List( [3..20], n -> Length( AllSmoothIntegers( [5,11,17], 10^n ) ) );
 [ 16, 29, 50, 78, 114, 155, 212, 282, 359, 452, 565, 691, 831, 992, 1173, 
   1374, 1595, 1843 ]
-]]>
-</Example>
+]]></Example>
 
 <ManSection>
    <Func Name="AllProducts"
@@ -66,8 +64,7 @@ there are bound to be repetitions.
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> AllProducts([1..4],3); 
 [ 1, 2, 3, 4, 2, 4, 6, 8, 3, 6, 9, 12, 4, 8, 12, 16, 2, 4, 6, 8, 4, 8, 12, 
   16, 6, 12, 18, 24, 8, 16, 24, 32, 3, 6, 9, 12, 6, 12, 18, 24, 9, 18, 27, 
@@ -77,8 +74,7 @@ gap> Set(last);
 [ 1, 2, 3, 4, 6, 8, 9, 12, 16, 18, 24, 27, 32, 36, 48, 64 ]
 gap> AllProducts( [(1,2,3),(2,3,4)], 2 );
 [ (2,4,3), (1,2)(3,4), (1,3)(2,4), (1,3,2) ]
-]]>
-</Example>
+]]></Example>
 
 <ManSection>
    <Func Name="RestrictedPartitionsWithoutRepetitions"
@@ -93,8 +89,7 @@ Unlike <C>RestrictedPartitions</C>, no repetitions are allowed.
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> RestrictedPartitions( 20, [4..10] );
 [ [ 4, 4, 4, 4, 4 ], [ 5, 5, 5, 5 ], [ 6, 5, 5, 4 ], [ 6, 6, 4, 4 ], 
   [ 7, 5, 4, 4 ], [ 7, 7, 6 ], [ 8, 4, 4, 4 ], [ 8, 6, 6 ], [ 8, 7, 5 ], 
@@ -104,8 +99,7 @@ gap> RestrictedPartitionsWithoutRepetitions( 20, [4..10] );
 [ [ 10, 6, 4 ], [ 9, 7, 4 ], [ 9, 6, 5 ], [ 8, 7, 5 ] ]
 gap> RestrictedPartitionsWithoutRepetitions( 10^2, List([1..10], n->n^2 ) );
 [ [ 100 ], [ 64, 36 ], [ 49, 25, 16, 9, 1 ] ]
-]]>
-</Example>
+]]></Example>
 
 <ManSection>
    <Func Name="NextProbablyPrimeInt"
@@ -122,8 +116,7 @@ For large <A>n</A>, this function is much faster than
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> n := 2^251;
 3618502788666131106986593281521497120414687020801267626233049500247285301248
 gap> NextProbablyPrimeInt( n );
@@ -134,8 +127,7 @@ gap> NextPrimeInt( n );
 3618502788666131106986593281521497120414687020801267626233049500247285301313
 gap> time;             
 213
-]]>
-</Example>
+]]></Example>
 
 <ManSection>
    <Func Name="PrimeNumbersIterator"
@@ -153,8 +145,7 @@ consecutive primes within the range one intends to run the iterator over.
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> iter := PrimeNumbersIterator();;
 gap> for i in [1..100] do  p := NextIterator(iter);  od;
 gap> p;
@@ -167,8 +158,7 @@ gap> for p in PrimeNumbersIterator() do
 >    od;
 gap> p;
 26861
-]]>
-</Example>
+]]></Example>
 
 
 </Section>

--- a/doc/obsolete.xml
+++ b/doc/obsolete.xml
@@ -46,8 +46,7 @@ Since a very similar result may be achieved using the &GAP;
 library functions <C>Perform</C> and <C>Display</C>, 
 this function became obsolete in version 0.61. 
 <P/>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> s3 := SymmetricGroup( 3 );; 
 gap> L := KnownPropertiesOfObject( GeneratorsOfGroup( s3 ) );;
 gap> Perform( L, Display );
@@ -63,8 +62,7 @@ gap> Perform( s3, Display );
 (1,3,2)
 (1,2,3)
 (1,2)
-]]>
-</Example>
+]]></Example>
 
 </Section>
 
@@ -79,8 +77,7 @@ which was included in versions from 0.41 to 0.58,
 has been removed since it was considered superfluous. 
 The example shows how to print out a function. 
 <P/> 
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> ApplicableMethod( IsCyclic, [ Group((1,2,3),(4,5)) ], 1, 1 );
 #I  Searching Method for IsCyclic with 1 arguments:
 #I  Total: 7 entries
@@ -102,8 +99,7 @@ gap> Print( last );
 function ( <<arg-1>> )
     <<compiled GAP code from GAPROOT/lib/oper1.g:578>>
 end
-]]>
-</Example>
+]]></Example>
 
 </Subsection>
 

--- a/doc/others.xml
+++ b/doc/others.xml
@@ -33,15 +33,13 @@ which you can adjust to your taste.
 </Description>
 </ManSection>
 <P/>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> LogTo( "triv.log" );
 gap> a := 33^5;
 39135393
 gap> LogTo(); 
 gap> Log2HTML( "triv.log" );     
-]]>
-</Example>
+]]></Example>
 
 </Section>
 
@@ -60,14 +58,12 @@ This function has been transferred from package &ResClasses;.
 </Description>
 </ManSection>
 <P/>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> IntOrInfinityToLaTeX( 10^3 );
 "1000"
 gap> IntOrInfinityToLaTeX( infinity );
 "\\infty"
-]]>
-</Example>
+]]></Example>
 
 <ManSection>
   <Func Name="LaTeXStringFactorsInt" 
@@ -81,12 +77,10 @@ It returns the prime factorization of the integer <M>n</M> as a string in
 </Description>
 </ManSection>
 <P/>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> LaTeXStringFactorsInt( Factorial(12) );
 "2^{10} \\cdot 3^5 \\cdot 5^2 \\cdot 7 \\cdot 11"
-]]>
-</Example>
+]]></Example>
 
 </Section>
 
@@ -129,8 +123,7 @@ and more testing is desirable.
 </Description>
 </ManSection>
 <P/>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> ## permutation groups
 gap> ConvertToMagmaInputString( Group( (1,2,3,4,5), (3,4,5) ) );
 "PermutationGroup<5|(1,2,3,4,5),\n(3,4,5)>;\n"
@@ -175,8 +168,7 @@ P![ 1, 1, 1,w^1],
 P![ 1,w^3, 2,w^2]
 ];
 gpN := sub<P | gens>;
-]]>
-</Example>
+]]></Example>
 
 </Section>
 

--- a/doc/print.xml
+++ b/doc/print.xml
@@ -46,8 +46,7 @@ only the items at positions in <C>L</C> are printed.
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> L := List( [1..20], n -> n^5 );;
 gap> PrintSelection( L, [18..20] );
 18 : 1889568
@@ -78,8 +77,7 @@ gap> PrintSelection( s5, 9, 11, 43 );
 20 : (2,4)
 31 : (1,5,2)
 42 : (1,5,2,3,4)
-]]>
-</Example>
+]]></Example>
 
 </Section>
 

--- a/doc/record.xml
+++ b/doc/record.xml
@@ -25,16 +25,14 @@ to global variables with the same names.
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> r := rec( a := 1, b := 2, c := 3 );;                                      
 gap> AssignGlobals( r );
 The following global variables have been assigned:
 [ "a", "b", "c" ]
 gap> [a,b,c];
 [ 1, 2, 3 ]
-]]>
-</Example> 
+]]></Example> 
 
 </Section> 
 
@@ -66,8 +64,7 @@ this record is used as <A>useroptions</A>.
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> defaults := rec( a := 1, b := 2, c := 3 );;
 gap> OptionRecordWithDefaults( defaults, rec( a := 6) );
 rec( a := 6, b := 2, c := 3 )
@@ -83,8 +80,7 @@ gap> OptionRecordWithDefaults( defaults, [ rec( b := 7 ), rec( c := 8 ) ] );
 Error, Too many arguments for function
 gap> OptionRecordWithDefaults( defaults, [6,7,8] );
 Error, Too many arguments for function
-]]>
-</Example>
+]]></Example>
 
 This function is designed to support functions with optional arguments 
 given as a variable record, of the form <C>function(x,y,options...)</C>. 
@@ -97,8 +93,7 @@ If there is a second argument, then
 <C>OptionRecordWithDefaults( order, arg[2] );</C> is used to cvhange the values. 
 These three values then determine the order in which the three dimensions are printed using a <C>SortParallel</C> command. 
 
-<Listing>
-<![CDATA[
+<Listing><![CDATA[
 PrintDimensions := function( arg ) 
     local nargs, dim, order, V, L, len, K, i; 
     nargs := Length( arg ); 
@@ -125,16 +120,14 @@ In the second call, alternate values for <C>h</C>, <C>w</C> and <C>d</C>
 are given, causing the width to be printed first, 
 and then the depth and height.
 
-<Example>
-<![CDATA[
+<Example><![CDATA[
 gap> mydim := rec( height := 45, width := 31, depth := 17 ); 
 rec( depth := 17, height := 45, width := 31 )
 gap> PrintDimensions( mydim );
 dimensions: height = 45, width = 31, depth = 17
 gap> PrintDimensions( mydim, rec( h:=3, w:=1, d:=2 ) );
 dimensions: width = 31, depth = 17, height = 45
-]]>
-</Example>
+]]></Example>
 
 </Section>
 

--- a/doc/template.xml
+++ b/doc/template.xml
@@ -27,10 +27,8 @@ They
 <P/>
 </Description>
 </ManSection>
-<Example>
-<![CDATA[
-]]>
-</Example>
+<Example><![CDATA[
+]]></Example>
 
 </Section>
 

--- a/doc/transfer.xml
+++ b/doc/transfer.xml
@@ -55,16 +55,14 @@ removed, and to specify &Utils; as a required package.
 (&Utils;:)
 Add strings <A>"home"</A> and <A>"m.n"</A> to the list 
 <C>UtilsPackageVersions</C> in the file <File>utils/lib/start.gd</File>. 
-<Example>
-<![CDATA[
+<Example><![CDATA[
 UtilsPackageVersions := 
   [ "autodoc",     "2016.01.31", 
     "resclasses",  "4.2.5", 
     "home",        "m.n",
     ...,           ... 
   ];
-]]>
-</Example>
+]]></Example>
 While the transfers are being made, it is essential that any new versions 
 of &Home; should be tested with the latest version of &Utils; 
 before they are released, so as to avoid loading failures.  
@@ -73,15 +71,13 @@ before they are released, so as to avoid loading failures.
 (&Utils;:)
 Include the function declaration and implementation sections 
 in suitable files, enclosed within a conditional clause of the form: 
-<Example>
-<![CDATA[
+<Example><![CDATA[
 if OKtoReadFromUtils( "Home" ) then
 . . . . . . 
  <the code> 
 . . . . . . 
 fi;
-]]>
-</Example> 
+]]></Example> 
 <Index>OKtoReadFromUtils</Index>
 The function <C>OKtoReadFromUtils</C> returns <K>true</K> 
 only if there is an installed version of &Home; 


### PR DESCRIPTION
Remove a bunch of undesirable leading and trailing empty lines visible in the generated manual.

CC @ThomasBreuer : I have a script for fixing this kind of mismatch, which I noticed when trying to use `extract_examples` here...

