### PR TITLE
tst/testall.g: set nopdf global option for makedoc.g

### DIFF
--- a/tst/testall.g
+++ b/tst/testall.g
@@ -15,7 +15,9 @@ if not UtilsLoadingComplete then
 fi; 
 
 # Create/update the testfiles containing the manual examples.
-ReadPackage( "utils", "makedoc.g" );
+# (The "nopdf" option informs AutoDoc that it can skip generating
+# PDF files, which makes this much faster)
+ReadPackage( "utils", "makedoc.g" : nopdf );
 
 dir := DirectoriesPackageLibrary( "utils", "tst" );
 TestDirectory(dir, rec(exitGAP := true,


### PR DESCRIPTION
With AutoDoc >= 2026.03.17 this skips calls to LaTex and thus
makes it run faster.
