### PR TITLE
Avoid using the small groups library

### DIFF
--- a/doc/groups.xml
+++ b/doc/groups.xml
@@ -355,7 +355,7 @@ gap> c1 := Centre( g1 );
 Group([ f3 ])
 gap> cp1 := CentralProduct( g1, g1, c1, IdentityMapping( c1 ) );
 Group([ f1, f2, f5, f3, f4, f5 ])
-gap> IdGroup( cp1 ) = IdGroup( ExtraspecialGroup( 2^5, "+" ) );
+gap> IsomorphismGroups( cp1, ExtraspecialGroup( 2^5, "+" ) ) <> fail;
 true
 gap> g2 := QuaternionGroup( 8 );
 <pc group of size 8 with 3 generators>
@@ -363,7 +363,7 @@ gap> c2 := Centre( g2 );
 Group([ y2 ])
 gap> cp2 := CentralProduct( g2, g2, c2, IdentityMapping( c2 ) );
 Group([ f1, f2, f5, f3, f4, f5 ])
-gap> IdGroup( cp2 ) = IdGroup( ExtraspecialGroup( 2^5, "+" ) );
+gap> IsomorphismGroups( cp1, ExtraspecialGroup( 2^5, "+" ) ) <> fail;
 true
 gap> info2 := CentralProductInfo( cp2 );
 rec( phi := IdentityMapping( Group([ y2 ]) ), 

--- a/doc/iterator.xml
+++ b/doc/iterator.xml
@@ -41,7 +41,7 @@ iterated over (this is, of course, just the order of the automorphisms group).
 The operation <C>AllIsomorphisms</C> produces the list or isomorphisms.
 <P/> 
 <Example><![CDATA[
-gap> G := SmallGroup( 6,1);; 
+gap> G := DihedralGroup(6);;
 gap> iter := AllIsomorphismsIterator( G, s3 );;
 gap> NextIterator( iter );
 [ f1, f2 ] -> [ (6,7), (5,6,7) ]

--- a/tst/groups.tst
+++ b/tst/groups.tst
@@ -148,7 +148,7 @@ gap> c1 := Centre( g1 );
 Group([ f3 ])
 gap> cp1 := CentralProduct( g1, g1, c1, IdentityMapping( c1 ) );
 Group([ f1, f2, f5, f3, f4, f5 ])
-gap> IdGroup( cp1 ) = IdGroup( ExtraspecialGroup( 2^5, "+" ) );
+gap> IsomorphismGroups( cp1, ExtraspecialGroup( 2^5, "+" ) ) <> fail;
 true
 gap> g2 := QuaternionGroup( 8 );
 <pc group of size 8 with 3 generators>
@@ -156,7 +156,7 @@ gap> c2 := Centre( g2 );
 Group([ y2 ])
 gap> cp2 := CentralProduct( g2, g2, c2, IdentityMapping( c2 ) );
 Group([ f1, f2, f5, f3, f4, f5 ])
-gap> IdGroup( cp2 ) = IdGroup( ExtraspecialGroup( 2^5, "+" ) );
+gap> IsomorphismGroups( cp2, ExtraspecialGroup( 2^5, "+" ) ) <> fail;
 true
 gap> info2 := CentralProductInfo( cp2 );
 rec( phi := IdentityMapping( Group([ y2 ]) ), 

--- a/tst/iterator.tst
+++ b/tst/iterator.tst
@@ -13,7 +13,7 @@ gap> UtilsLoadingComplete;
 true
 
 ## SubSection 7.1.1 
-gap> G := SmallGroup( 6,1);; 
+gap> G := DihedralGroup(6);;
 gap> s3 := Group( (5,6), (6,7) );; 
 gap> iter := AllIsomorphismsIterator( G, s3 );;
 gap> NextIterator( iter );


### PR DESCRIPTION
There is no reason to use it for these simple examples.

This is a minor step towards enabling running GAP without our
group libraries.
