### PR TITLE
Make `TestPackage` work if the package is read-only

### DIFF
--- a/tst/testall.g
+++ b/tst/testall.g
@@ -14,10 +14,20 @@ if not UtilsLoadingComplete then
     ReadPackage( "utils", "tst/loadall.g" ); 
 fi; 
 
-# Create/update the testfiles containing the manual examples.
-# (The "nopdf" option informs AutoDoc that it can skip generating
-# PDF files, which makes this much faster)
-ReadPackage( "utils", "makedoc.g" : nopdf );
+tstdir:= DirectoriesPackageLibrary( "utils", "tst" );
+tstfile:= Filename( tstdir[1], "utils01.tst" );
+tstdir:= Filename( tstdir, "" );
+if IsWritableFile( tstdir ) and
+   ( IsWritableFile( tstfile ) or not IsExistingFile( tstfile ) ) then
+  # Create/update the testfiles containing the manual examples.
+  # (The "nopdf" option informs AutoDoc that it can skip generating
+  # PDF files, which makes this much faster)
+  ReadPackage( "utils", "makedoc.g" : nopdf );
+elif not IsExistingFile( tstfile ) then
+  Print( "The testfiles with manual examples are missing ",
+         "and cannot get written.\n" );
+  QUIT_GAP(1);
+fi;
 
 dir := DirectoriesPackageLibrary( "utils", "tst" );
 TestDirectory(dir, rec(exitGAP := true,


### PR DESCRIPTION
We want to run the package tests in the following situations.

- In CI tests for the package, the package manual has not been built. In order to run also the manual examples, we read the package's `makedoc.g`. This works because the `doc` and `tst`directories are writable.

- When the package has been installed, its `doc` and `tst` directories are in general *not* writable. In this case, we expect that test files containing the manual examples are available, and we do not read `makedoc.g`. The files with manual examples have names `utils*.tst`, if `utils01.tst` does not exist, `testall.g` reports a test failure.

This is intended to resolve a problem discussed in oscar-system/GAP.jl/pull/1379.