### PR TITLE
Update CI to use setup-gap@v3; require curlInterface 2.4.0 for timeout support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,9 @@ jobs:
       - uses: gap-actions/setup-gap@v3
         with:
           gap-version: ${{ matrix.gap-version }}
+      - uses: gap-actions/install-pkg@v1
+        with:
+          packages: "curlInterface@2.4.0"
       - uses: gap-actions/build-pkg@v3
         with:
           extra-pkgs: "io nq profiling"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,32 +19,33 @@ concurrency:
 jobs:
   # The CI test job
   test:
-    name: ${{ matrix.gap-branch }}
+    name: ${{ matrix.gap-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        gap-branch:
-          - master
-          - stable-4.16
-          - stable-4.15
-          - stable-4.14
-          - stable-4.13
-          - stable-4.12
-        #  - stable-4.11
+        gap-version:
+          - 'devel'   # current GAP development version from git
+          - 'latest'  # latest GAP release
+          - 'minimal' # oldest GAP release supported by this package
 
     steps:
       - uses: actions/checkout@v6
-      - uses: gap-actions/setup-gap@v2
+      - name: 'Install libcurl for curlInterface'
+        run: |
+          sudo apt-get update
+          sudo apt-get install libcurl4-gnutls-dev
+      - uses: gap-actions/setup-gap@v3
         with:
-          GAP_PKGS_TO_BUILD: "io nq profiling"
-          GAPBRANCH: ${{ matrix.gap-branch }}
-      - uses: gap-actions/build-pkg@v1
-      - uses: gap-actions/run-pkg-tests@v3
-      - uses: gap-actions/run-pkg-tests@v3
+          gap-version: ${{ matrix.gap-version }}
+      - uses: gap-actions/build-pkg@v3
         with:
-          only-needed: true
-      - uses: gap-actions/process-coverage@v2
+          extra-pkgs: "io nq profiling"
+      - uses: gap-actions/run-pkg-tests@v4
+      - uses: gap-actions/run-pkg-tests@v4
+        with:
+          mode: onlyneeded
+      - uses: gap-actions/process-coverage@v3
       - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -123,7 +123,7 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">=4.10.1",
+  GAP := ">=4.12",
   NeededOtherPackages := [ ], 
   SuggestedOtherPackages := [ [ "curlInterface", ">= 2.3.0" ] ],
   TestPackages := [ [ "io", ">= 4.7.0" ] ],

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -125,7 +125,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">=4.12",
   NeededOtherPackages := [ ], 
-  SuggestedOtherPackages := [ [ "curlInterface", ">= 2.3.0" ] ],
+  SuggestedOtherPackages := [ [ "curlInterface", ">= 2.4.0" ] ],
   TestPackages := [ [ "io", ">= 4.7.0" ] ],
   ExternalConditions := [ ]
 ),


### PR DESCRIPTION
This reverts commit 9a1dabb1a2a609cbed2ccb5c3395f1afde905c33 / relands PR #95.

Moreover, it changes utils to require curlInterface 2.4.0, as that is needed for timeout support in `Download`.