### PR TITLE
Download: do not modify the caller's options record

### DIFF
--- a/lib/download.gi
+++ b/lib/download.gi
@@ -247,6 +247,9 @@ InstallMethod( Download,
     function( url, opt )
     local timeout, errors, r, res;
 
+    # Do not modify the caller's record when filling in the defaults below.
+    opt:= ShallowCopy( opt );
+
     # Set the default for 'verifyCert' if necessary.
     if not IsBound( opt.verifyCert ) and
        UserPreference( "utils", "DownloadVerifyCertificate" ) = false then

--- a/tst/download.tst
+++ b/tst/download.tst
@@ -1,4 +1,4 @@
-#@local meths, i, urls, pair, url, expected, res1, good1, n, file, res2, good2, contents, r, res3, good3, bad, server, baseurl, iometh
+#@local meths, i, urls, pair, url, expected, res1, good1, n, file, res2, good2, contents, r, res3, good3, bad, server, baseurl, iometh, opt, oldpref
 ############################################################################
 ##
 #W  download.tst               Utils Package                   Thomas Breuer
@@ -138,6 +138,19 @@ true
 gap> res1:= Download( url, rec( maxTime:= 5 ) );;
 gap> res1.success = true;
 true
+
+##  'Download' must not modify the given options record.
+##  The defaults are filled in only when the preferences differ from their
+##  default values, hence the 'SetUserPreference' call.
+gap> oldpref:= UserPreference( "utils", "DownloadMaxTime" );;
+gap> SetUserPreference( "utils", "DownloadMaxTime", 30 );
+gap> opt:= rec();;
+gap> res1:= Download( Concatenation( baseurl, "/success" ), opt );;
+gap> res1.success;
+true
+gap> RecNames( opt );
+[  ]
+gap> SetUserPreference( "utils", "DownloadMaxTime", oldpref );
 
 ##  test errors and redirects
 gap> res1:= Download( Concatenation( baseurl, "/missing" ) );;


### PR DESCRIPTION
`Download` fills in the defaults for `verifyCert` and `maxTime` by writing into
the record the caller passed, so a record reused across calls keeps the first
call's settings.

It only happens once a preference differs from its default — with the shipped
values neither branch is taken — so it is invisible to anyone testing a stock
configuration:

```gap
gap> SetUserPreference( "utils", "DownloadMaxTime", 30 );
gap> opt:= rec();;
gap> Download( "file:///nonexistent", opt );;
gap> opt;
rec( maxTime := 30 )
```

One `ShallowCopy` fixes it; the `via DownloadURL` method already copies before
touching the record. The test sets the preference first, for the reason above.

*Written with Claude Opus 5 via Claude Code; reviewed by me.*
